### PR TITLE
Expose a Server Hub Context

### DIFF
--- a/src/NexNet.IntegrationTests/BaseTests.cs
+++ b/src/NexNet.IntegrationTests/BaseTests.cs
@@ -155,6 +155,27 @@ public class BaseTests
         return (server, serverHub, client, clientHub);
     }
 
+    protected NexNetServer<ServerHub, ServerHub.ClientProxy>
+        CreateServer(ServerConfig sConfig, Action<ServerHub>? hubCreated)
+    {
+        var server = ServerHub.CreateServer(sConfig, () =>
+        {
+            var hub = new ServerHub();
+            hubCreated?.Invoke(hub);
+            return hub;
+        });
+        return server;
+    }
+
+    protected (NexNetClient<ClientHub, ClientHub.ServerProxy> client, ClientHub clientHub)
+        CreateClient(ClientConfig cConfig)
+    {
+        var clientHub = new ClientHub();
+        var client = ClientHub.CreateClient(cConfig, clientHub);
+
+        return (client, clientHub);
+    }
+
     private int FreeTcpPort()
     {
         TcpListener l = new TcpListener(IPAddress.Loopback, 0);

--- a/src/NexNet.IntegrationTests/NexNetServerTests.cs
+++ b/src/NexNet.IntegrationTests/NexNetServerTests.cs
@@ -61,7 +61,7 @@ internal partial class NexNetServerTests : BaseTests
             CreateClientConfig(type, false));
 
 
-        for (int i = 0; i < 5; i++)
+        for (int i = 0; i < 3; i++)
         {
             server.Start();
             await client.ConnectAsync().WaitAsync(TimeSpan.FromSeconds(1));
@@ -77,6 +77,4 @@ internal partial class NexNetServerTests : BaseTests
 
         }
     }
-
-
 }

--- a/src/NexNet.IntegrationTests/NexNetServerTests_HubInvocations.cs
+++ b/src/NexNet.IntegrationTests/NexNetServerTests_HubInvocations.cs
@@ -1,0 +1,374 @@
+﻿using NexNet.IntegrationTests.TestInterfaces;
+using NUnit.Framework;
+#pragma warning disable VSTHRD200
+
+namespace NexNet.IntegrationTests;
+
+internal partial class NexNetServerTests_HubInvocations : BaseTests
+{
+    //[Test]
+    [TestCase(Type.Uds)]
+    [TestCase(Type.Tcp)]
+    [TestCase(Type.TcpTls)]
+    public async Task InvokesViaHubContext(Type type)
+    {
+        var tcs = new TaskCompletionSource();
+        var (server, _, client, clientHub) = CreateServerClient(
+            CreateServerConfig(type, false),
+            CreateClientConfig(type, false));
+
+        clientHub.ClientTaskEvent = async _ => tcs.SetResult();
+
+        server.Start();
+        await client.ConnectAsync().WaitAsync(TimeSpan.FromSeconds(1));
+
+        await clientHub.ConnectedTCS.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+        using var context = server.GetContext();
+        await context.Clients.All.ClientTask();
+        await tcs.Task.WaitAsync(TimeSpan.FromSeconds(1));
+    }
+
+    [Test]
+    [TestCase(Type.Uds)]
+    [TestCase(Type.Tcp)]
+    [TestCase(Type.TcpTls)]
+    public async Task InvokesViaHubContextAndDoesNotBlock(Type type)
+    {
+        bool completed = false;
+        var (server, serverHub, client, clientHub) = CreateServerClient(
+            CreateServerConfig(type, false),
+            CreateClientConfig(type, false));
+
+        clientHub.ClientTaskEvent = async _ =>
+        {
+            await Task.Delay(10000);
+            completed = true;
+        };
+
+        serverHub.OnConnectedEvent = hub =>
+        {
+            hub.Context.AddToGroup("myGroup");
+            return ValueTask.CompletedTask;
+        };
+
+        server.Start();
+        await client.ConnectAsync().WaitAsync(TimeSpan.FromSeconds(1));
+
+        await clientHub.ConnectedTCS.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+        using var context = server.GetContext();
+        await context.Clients.All.ClientTask();
+        await context.Clients.Clients(context.GetClientIds().ToArray()).ClientTask();
+        await context.Clients.Group("myGroup").ClientTask();
+        await context.Clients.Groups(new[] { "myGroup" }).ClientTask();
+        Assert.IsFalse(completed);
+    }
+
+    [TestCase(Type.Uds)]
+    [TestCase(Type.Tcp)]
+    [TestCase(Type.TcpTls)]
+    public async Task InvokesViaHubAndDoesNotBlock(Type type)
+    {
+        bool completed = false;
+        var tcs1 = new TaskCompletionSource();
+        NexNetServer<ServerHub, ServerHub.ClientProxy> server = null;
+        server = CreateServer(CreateServerConfig(type, false), connectedHub =>
+        {
+            connectedHub.OnConnectedEvent = async hub =>
+            {
+                hub.Context.AddToGroup("myGroup");
+
+                await hub.Context.Clients.All.ClientTask();
+                await hub.Context.Clients.Clients(server.GetContext().GetClientIds().ToArray()).ClientTask();
+                await hub.Context.Clients.Group("myGroup").ClientTask();
+                await hub.Context.Clients.Groups(new[] { "myGroup" }).ClientTask();
+                Assert.IsFalse(completed);
+                tcs1.SetResult();
+            };
+        });
+
+        var (client1, clientHub1) = CreateClient(CreateClientConfig(type, false));
+
+        clientHub1.ClientTaskEvent = async _ =>
+        {
+            await Task.Delay(10000);
+            completed = true;
+        };
+
+        server.Start();
+
+        await client1.ConnectAsync().WaitAsync(TimeSpan.FromSeconds(1));
+
+        await clientHub1.ConnectedTCS.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+        await tcs1.Task.WaitAsync(TimeSpan.FromSeconds(1));
+    }
+
+    //[Test]
+    [TestCase(Type.Uds)]
+    [TestCase(Type.Tcp)]
+    [TestCase(Type.TcpTls)]
+    public async Task InvokesViaHubContextAndGetsReturnFromSingleClient(Type type)
+    {
+        var (server, _, client, clientHub) = CreateServerClient(
+            CreateServerConfig(type, false),
+            CreateClientConfig(type, false));
+
+        clientHub.ClientTaskValueEvent = _ => ValueTask.FromResult(54321);
+
+        server.Start();
+        await client.ConnectAsync().WaitAsync(TimeSpan.FromSeconds(1));
+
+        await clientHub.ConnectedTCS.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+        using var context = server.GetContext();
+
+        var result = await context.Clients.Client(context.GetClientIds().First()).ClientTaskValue();
+
+        Assert.AreEqual(54321, result);
+    }
+
+    [TestCase(Type.Uds)]
+    [TestCase(Type.Tcp)]
+    [TestCase(Type.TcpTls)]
+    public async Task HubInvokesOnAll(Type type)
+    {
+        var tcs1 = new TaskCompletionSource();
+        var tcs2 = new TaskCompletionSource();
+        int connectedCount = 0;
+        var server = CreateServer(CreateServerConfig(type, false), connectedHub =>
+        {
+            connectedHub.OnConnectedEvent = async hub =>
+            {
+                // Second connection
+                if (++connectedCount == 2)
+                {
+                    await hub.Context.Clients.All.ClientTask();
+                }
+            };
+        });
+
+        var (client1, clientHub1) = CreateClient(CreateClientConfig(type, false));
+        var (client2, clientHub2) = CreateClient(CreateClientConfig(type, false));
+
+        clientHub1.ClientTaskEvent = async _ => tcs1.TrySetResult();
+        clientHub2.ClientTaskEvent = async _ => tcs2.TrySetResult();
+
+        server.Start();
+
+        await client1.ConnectAsync().WaitAsync(TimeSpan.FromSeconds(1));
+        await client2.ConnectAsync().WaitAsync(TimeSpan.FromSeconds(1));
+
+        await clientHub1.ConnectedTCS.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        await clientHub2.ConnectedTCS.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        
+        await tcs1.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        await tcs2.Task.WaitAsync(TimeSpan.FromSeconds(1));
+    }
+
+    [TestCase(Type.Uds)]
+    [TestCase(Type.Tcp)]
+    [TestCase(Type.TcpTls)]
+    public async Task HubInvokesOnGroup(Type type)
+    {
+        var tcs1 = new TaskCompletionSource();
+        var tcs2 = new TaskCompletionSource();
+        int connectedCount = 0;
+        var server = CreateServer(CreateServerConfig(type, false), connectedHub =>
+        {
+            connectedHub.OnConnectedEvent = async hub =>
+            {
+                hub.Context.AddToGroup("group");
+                // Second connection
+                if (++connectedCount == 2)
+                {
+                    await hub.Context.Clients.Group("group").ClientTask();
+                }
+            };
+        });
+
+        var (client1, clientHub1) = CreateClient(CreateClientConfig(type, false));
+        var (client2, clientHub2) = CreateClient(CreateClientConfig(type, false));
+
+        clientHub1.ClientTaskEvent = async _ => tcs1.TrySetResult();
+        clientHub2.ClientTaskEvent = async _ => tcs2.TrySetResult();
+
+        server.Start();
+
+        await client1.ConnectAsync().WaitAsync(TimeSpan.FromSeconds(1));
+        await client2.ConnectAsync().WaitAsync(TimeSpan.FromSeconds(1));
+
+        await clientHub1.ConnectedTCS.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        await clientHub2.ConnectedTCS.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+        await tcs1.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        await tcs2.Task.WaitAsync(TimeSpan.FromSeconds(1));
+    }
+
+    [TestCase(Type.Uds)]
+    [TestCase(Type.Tcp)]
+    [TestCase(Type.TcpTls)]
+    public async Task HubInvokesOnGroups(Type type)
+    {
+        var tcs1 = new TaskCompletionSource();
+        var tcs2 = new TaskCompletionSource();
+        int connectedCount = 0;
+        var server = CreateServer(CreateServerConfig(type, false), connectedHub =>
+        {
+            connectedHub.OnConnectedEvent = async hub =>
+            {
+                if (++connectedCount == 1) {
+                    hub.Context.AddToGroup("group");
+                }
+                // Second connection
+                if (connectedCount == 2)
+                {
+                    hub.Context.AddToGroup("group2");
+                    await hub.Context.Clients.Groups(new []{ "group" , "group2" }).ClientTask();
+                }
+            };
+        });
+
+        var (client1, clientHub1) = CreateClient(CreateClientConfig(type, false));
+        var (client2, clientHub2) = CreateClient(CreateClientConfig(type, false));
+
+        clientHub1.ClientTaskEvent = async _ => tcs1.TrySetResult();
+        clientHub2.ClientTaskEvent = async _ => tcs2.TrySetResult();
+
+        server.Start();
+
+        await client1.ConnectAsync().WaitAsync(TimeSpan.FromSeconds(1));
+        await client2.ConnectAsync().WaitAsync(TimeSpan.FromSeconds(1));
+
+        await clientHub1.ConnectedTCS.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        await clientHub2.ConnectedTCS.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+        await tcs1.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        await tcs2.Task.WaitAsync(TimeSpan.FromSeconds(1));
+    }
+
+    [TestCase(Type.Uds)]
+    [TestCase(Type.Tcp)]
+    [TestCase(Type.TcpTls)]
+    public async Task HubInvokesOnOthers(Type type)
+    {
+        var tcs = new TaskCompletionSource();
+
+        int connectedCount = 0;
+        int invocationCount = 0;
+        var server = CreateServer(CreateServerConfig(type, false), connectedHub =>
+        {
+            connectedHub.OnConnectedEvent = async hub =>
+            {
+                // Second connection
+                if (++connectedCount == 2)
+                {
+                    await hub.Context.Clients.Others.ClientTask();
+                    await Task.Delay(10);
+                    tcs.SetResult();
+                }
+            };
+        });
+
+        var (client1, clientHub1) = CreateClient(CreateClientConfig(type, false));
+        var (client2, clientHub2) = CreateClient(CreateClientConfig(type, false));
+
+        clientHub1.ClientTaskEvent = async _ => invocationCount++;
+        clientHub2.ClientTaskEvent = async _ => invocationCount++;
+
+        server.Start();
+
+        await client1.ConnectAsync().WaitAsync(TimeSpan.FromSeconds(1));
+        await client2.ConnectAsync().WaitAsync(TimeSpan.FromSeconds(1));
+
+        await clientHub1.ConnectedTCS.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        await clientHub2.ConnectedTCS.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+        await tcs.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+        Assert.AreEqual(1, invocationCount);
+    }
+
+    [TestCase(Type.Uds)]
+    [TestCase(Type.Tcp)]
+    [TestCase(Type.TcpTls)]
+    public async Task HubInvokesOnClient(Type type)
+    {
+        var tcs = new TaskCompletionSource();
+
+        int connectedCount = 0;
+        int invocationCount = 0;
+        var server = CreateServer(CreateServerConfig(type, false), connectedHub =>
+        {
+            connectedHub.OnConnectedEvent = async hub =>
+            {
+                // Second connection
+                if (++connectedCount == 2)
+                {
+                    await hub.Context.Clients.Client(hub.Context.Id).ClientTask();
+                    await Task.Delay(10);
+                    tcs.SetResult();
+                }
+            };
+        });
+
+        var (client1, clientHub1) = CreateClient(CreateClientConfig(type, false));
+        var (client2, clientHub2) = CreateClient(CreateClientConfig(type, false));
+
+        clientHub1.ClientTaskEvent = async _ => invocationCount++;
+        clientHub2.ClientTaskEvent = async _ => invocationCount++;
+
+        server.Start();
+
+        await client1.ConnectAsync().WaitAsync(TimeSpan.FromSeconds(1));
+        await client2.ConnectAsync().WaitAsync(TimeSpan.FromSeconds(1));
+
+        await clientHub1.ConnectedTCS.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        await clientHub2.ConnectedTCS.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+        await tcs.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+        Assert.AreEqual(1, invocationCount);
+    }
+
+    [TestCase(Type.Uds)]
+    [TestCase(Type.Tcp)]
+    [TestCase(Type.TcpTls)]
+    public async Task HubInvokesOnClients(Type type)
+    {
+        var tcs1 = new TaskCompletionSource();
+        var tcs2 = new TaskCompletionSource();
+        int connectedCount = 0;
+        NexNetServer<ServerHub, ServerHub.ClientProxy> server = null;
+        server = CreateServer(CreateServerConfig(type, false), connectedHub =>
+        {
+            connectedHub.OnConnectedEvent = async hub =>
+            {
+                // Second connection
+                if (++connectedCount == 2)
+                {
+                    var clientIds = server!.GetContext().GetClientIds().ToArray();
+                    await hub.Context.Clients.Clients(clientIds).ClientTask();
+                }
+            };
+        });
+
+        var (client1, clientHub1) = CreateClient(CreateClientConfig(type, false));
+        var (client2, clientHub2) = CreateClient(CreateClientConfig(type, false));
+
+        clientHub1.ClientTaskEvent = async _ => tcs1.TrySetResult();
+        clientHub2.ClientTaskEvent = async _ => tcs2.TrySetResult();
+
+        server.Start();
+
+        await client1.ConnectAsync().WaitAsync(TimeSpan.FromSeconds(1));
+        await client2.ConnectAsync().WaitAsync(TimeSpan.FromSeconds(1));
+
+        await clientHub1.ConnectedTCS.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        await clientHub2.ConnectedTCS.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+        await tcs1.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        await tcs2.Task.WaitAsync(TimeSpan.FromSeconds(1));
+    }
+}

--- a/src/NexNet/Cache/CachedProxy.cs
+++ b/src/NexNet/Cache/CachedProxy.cs
@@ -12,7 +12,7 @@ internal class CachedProxy<TProxy>
 
     public TProxy Rent(
         INexNetSession<TProxy> session,
-        SessionManager sessionManager,
+        SessionManager? sessionManager,
         ProxyInvocationMode mode,
         object? modeArguments)
     {

--- a/src/NexNet/Cache/CachedProxy.cs
+++ b/src/NexNet/Cache/CachedProxy.cs
@@ -12,6 +12,7 @@ internal class CachedProxy<TProxy>
 
     public TProxy Rent(
         INexNetSession<TProxy> session,
+        SessionManager sessionManager,
         ProxyInvocationMode mode,
         object? modeArguments)
     {
@@ -20,7 +21,7 @@ internal class CachedProxy<TProxy>
         if (!_cache.TryTake(out var proxy))
             proxy = new TProxy() { CacheManager = session.CacheManager };
 
-        proxy.Configure(session, mode, modeArguments);
+        proxy.Configure(session, sessionManager, mode, modeArguments);
 
 
         return proxy;

--- a/src/NexNet/Cache/CachedProxy.cs
+++ b/src/NexNet/Cache/CachedProxy.cs
@@ -10,16 +10,24 @@ internal class CachedProxy<TProxy>
 {
     private readonly ConcurrentBag<TProxy> _cache = new();
 
+    /// <summary>
+    /// Rents a proxy class.
+    /// </summary>
+    /// <param name="session">Session for this proxy.  Used in all cases except from the external hub context.</param>
+    /// <param name="sessionManager">Reference to the session manager.  Not used from client invocations.</param>
+    /// <param name="sessionCache">Cache for the sessions.</param>
+    /// <param name="mode">Mode to set this proxy to.</param>
+    /// <param name="modeArguments">Arguments to pass for this invocation mode.</param>
+    /// <returns></returns>
     public TProxy Rent(
-        INexNetSession<TProxy> session,
+        INexNetSession<TProxy>? session,
         SessionManager? sessionManager,
+        SessionCacheManager<TProxy> sessionCache,
         ProxyInvocationMode mode,
         object? modeArguments)
     {
-        ArgumentNullException.ThrowIfNull(session);
-
         if (!_cache.TryTake(out var proxy))
-            proxy = new TProxy() { CacheManager = session.CacheManager };
+            proxy = new TProxy() { CacheManager = sessionCache };
 
         proxy.Configure(session, sessionManager, mode, modeArguments);
 
@@ -27,11 +35,18 @@ internal class CachedProxy<TProxy>
         return proxy;
     }
 
-    public void Return(TProxy item)
+    /// <summary>
+    /// Returns the proxy for reuse.
+    /// </summary>
+    /// <param name="proxy">Proxy to return.</param>
+    public void Return(TProxy proxy)
     {
-        _cache.Add(item);
+        _cache.Add(proxy);
     }
 
+    /// <summary>
+    /// Clears the cache.
+    /// </summary>
     public void Clear()
     {
         _cache.Clear();

--- a/src/NexNet/INexNetServer.cs
+++ b/src/NexNet/INexNetServer.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Concurrent;
+using NexNet.Invocation;
+
+namespace NexNet;
+
+internal interface INexNetServer<TClientProxy>
+    where TClientProxy : ProxyInvocationBase, IProxyInvoker, new()
+{
+    /// <summary>
+    /// Cache for all the server hub contexts.
+    /// </summary>
+    ConcurrentBag<ServerHubContext<TClientProxy>> ServerHubContextCache { get; }
+}

--- a/src/NexNet/IServerHubContext.cs
+++ b/src/NexNet/IServerHubContext.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NexNet.Cache;
+using NexNet.Invocation;
+
+namespace NexNet;
+
+public class IServerHubContext<TProxy>
+    where TProxy : ProxyInvocationBase, IProxyInvoker, new()
+{
+    public IProxyBase<TProxy> Clients { get; set; }
+
+
+    private sealed class ClientProxy : IProxyBase<TProxy>
+    {
+        private readonly SessionCacheManager<TProxy> _cacheManager;
+        private readonly ServerSessionContext<TProxy> _context;
+        private readonly Stack<TProxy> _instancedProxies = new Stack<TProxy>();
+
+        private TProxy? _all;
+        public TProxy All
+        {
+            get => _all ??= _cacheManager.ProxyCache.Rent(_context.Session!, ProxyInvocationMode.All, null);
+        }
+
+        internal ClientProxy(SessionCacheManager<TProxy> cacheManager, ServerSessionContext<TProxy> context)
+        {
+            _cacheManager = cacheManager;
+            _context = context;
+        }
+
+
+        public TProxy Client(long id)
+        {
+            var proxy = _cacheManager.ProxyCache.Rent(
+                _context.Session!,
+                ProxyInvocationMode.Client,
+                new[] { id });
+            _instancedProxies.Push(proxy);
+
+            return proxy;
+        }
+
+        public TProxy Clients(long[] ids)
+        {
+            var proxy = _cacheManager.ProxyCache.Rent(
+                _context.Session!,
+                ProxyInvocationMode.Clients,
+                ids);
+            _instancedProxies.Push(proxy);
+
+            return proxy;
+        }
+
+        public TProxy Group(string groupName)
+        {
+            var proxy = _cacheManager.ProxyCache.Rent(
+                _context.Session!,
+                ProxyInvocationMode.Groups,
+                new[] { groupName });
+            _instancedProxies.Push(proxy);
+
+            return proxy;
+        }
+
+        public TProxy Groups(string[] groupName)
+        {
+            var proxy = _cacheManager.ProxyCache.Rent(
+                _context.Session!,
+                ProxyInvocationMode.Groups,
+                groupName);
+            _instancedProxies.Push(proxy);
+
+            return proxy;
+        }
+
+        public void Reset()
+        {
+            if (_caller != null)
+            {
+                _cacheManager.ProxyCache.Return(_caller);
+                _caller = null;
+            }
+
+            if (_all != null)
+            {
+                _cacheManager.ProxyCache.Return(_all);
+                _all = null;
+            }
+
+            if (_others != null)
+            {
+                _cacheManager.ProxyCache.Return(_others);
+                _others = null;
+            }
+
+            while (_instancedProxies.TryPop(out var proxy))
+            {
+                _cacheManager.ProxyCache.Return(proxy);
+            }
+        }
+    }
+}

--- a/src/NexNet/Invocation/ClientSessionContext.cs
+++ b/src/NexNet/Invocation/ClientSessionContext.cs
@@ -17,11 +17,11 @@ public sealed class ClientSessionContext<TProxy> : SessionContext<TProxy>
     /// </summary>
     public TProxy Proxy
     {
-        get => _proxy ??= CacheManager.ProxyCache.Rent(Session!, ProxyInvocationMode.Caller, null);
+        get => _proxy ??= CacheManager.ProxyCache.Rent(Session!, SessionManager, ProxyInvocationMode.Caller, null);
     }
 
     internal ClientSessionContext(INexNetSession<TProxy> session)
-        : base(session)
+        : base(session, null)
     {
     }
 

--- a/src/NexNet/Invocation/ClientSessionContext.cs
+++ b/src/NexNet/Invocation/ClientSessionContext.cs
@@ -17,7 +17,12 @@ public sealed class ClientSessionContext<TProxy> : SessionContext<TProxy>
     /// </summary>
     public TProxy Proxy
     {
-        get => _proxy ??= CacheManager.ProxyCache.Rent(Session!, SessionManager, ProxyInvocationMode.Caller, null);
+        get => _proxy ??= CacheManager.ProxyCache.Rent(
+            Session,
+            SessionManager,
+            Session.CacheManager,
+            ProxyInvocationMode.Caller,
+            null);
     }
 
     internal ClientSessionContext(INexNetSession<TProxy> session)

--- a/src/NexNet/Invocation/IProxyBase.cs
+++ b/src/NexNet/Invocation/IProxyBase.cs
@@ -1,0 +1,42 @@
+﻿namespace NexNet.Invocation;
+
+/// <summary>
+/// Interface for selection of clients to invoke methods on.
+/// </summary>
+/// <typeparam name="TProxy">Proxy class used for invocation.</typeparam>
+public interface IProxyBase<out TProxy>
+    where TProxy : ProxyInvocationBase, IProxyInvoker, new()
+{
+    /// <summary>
+    /// Proxy for all connected sessions.
+    /// </summary>
+    TProxy All { get; }
+
+    /// <summary>
+    /// Proxy for a specific client selected by session id.
+    /// </summary>
+    /// <param name="id">Session id to get a proxy for.</param>
+    /// <returns>Proxy</returns>
+    TProxy Client(long id);
+
+    /// <summary>
+    /// Proxy for a specific clients selected by session ids.
+    /// </summary>
+    /// <param name="ids">Session ids to get a proxies for.</param>
+    /// <returns>Proxy</returns>
+    TProxy Clients(long[] ids);
+
+    /// <summary>
+    /// Proxy for all clients part of the specified group.
+    /// </summary>
+    /// <param name="groupName">Group name to get the proxy for.</param>
+    /// <returns>Proxy</returns>
+    TProxy Group(string groupName);
+
+    /// <summary>
+    /// Proxy for all clients part of the specified groups.
+    /// </summary>
+    /// <param name="groupName">Group names to get the proxies for.</param>
+    /// <returns>Proxy</returns>
+    TProxy Groups(string[] groupName);
+}

--- a/src/NexNet/Invocation/IProxyClients.cs
+++ b/src/NexNet/Invocation/IProxyClients.cs
@@ -4,7 +4,7 @@
 /// Interface for selection of clients to invoke methods on.
 /// </summary>
 /// <typeparam name="TProxy">Proxy class used for invocation.</typeparam>
-public interface IProxyClients<out TProxy>
+public interface IProxyClients<out TProxy> : IProxyBase<TProxy>
     where TProxy : ProxyInvocationBase, IProxyInvoker, new()
 {
     /// <summary>
@@ -13,40 +13,7 @@ public interface IProxyClients<out TProxy>
     TProxy Caller { get; }
 
     /// <summary>
-    /// Proxy for all connected sessions.
-    /// </summary>
-    TProxy All { get; }
-
-    /// <summary>
     /// Proxy for all connected sessions except the current one.
     /// </summary>
     TProxy Others { get; }
-
-    /// <summary>
-    /// Proxy for a specific client selected by session id.
-    /// </summary>
-    /// <param name="id">Session id to get a proxy for.</param>
-    /// <returns>Proxy</returns>
-    TProxy Client(long id);
-
-    /// <summary>
-    /// Proxy for a specific clients selected by session ids.
-    /// </summary>
-    /// <param name="ids">Session ids to get a proxies for.</param>
-    /// <returns>Proxy</returns>
-    TProxy Clients(long[] ids);
-
-    /// <summary>
-    /// Proxy for all clients part of the specified group.
-    /// </summary>
-    /// <param name="groupName">Group name to get the proxy for.</param>
-    /// <returns>Proxy</returns>
-    TProxy Group(string groupName);
-
-    /// <summary>
-    /// Proxy for all clients part of the specified groups.
-    /// </summary>
-    /// <param name="groupName">Group names to get the proxies for.</param>
-    /// <returns>Proxy</returns>
-    TProxy Groups(string[] groupName);
 }

--- a/src/NexNet/Invocation/IProxyInvoker.cs
+++ b/src/NexNet/Invocation/IProxyInvoker.cs
@@ -9,7 +9,7 @@ public interface IProxyInvoker
 {
     internal void Configure(
         INexNetSession? session,
-        SessionManager sessionManager,
+        SessionManager? sessionManager,
         ProxyInvocationMode mode,
         object? modeArguments);
 }

--- a/src/NexNet/Invocation/IProxyInvoker.cs
+++ b/src/NexNet/Invocation/IProxyInvoker.cs
@@ -7,5 +7,9 @@ namespace NexNet.Invocation;
 /// </summary>
 public interface IProxyInvoker
 {
-    internal void Configure(INexNetSession session, ProxyInvocationMode mode, object? modeArguments);
+    internal void Configure(
+        INexNetSession? session,
+        SessionManager sessionManager,
+        ProxyInvocationMode mode,
+        object? modeArguments);
 }

--- a/src/NexNet/Invocation/ProxyInvocationBase.cs
+++ b/src/NexNet/Invocation/ProxyInvocationBase.cs
@@ -354,6 +354,7 @@ public abstract class ProxyInvocationBase : IProxyInvoker
         // If we are invoking on multiple sessions, then we are not going to wait
         // on the results on this proxy invocation.
         if (_mode == ProxyInvocationMode.All
+            || _mode == ProxyInvocationMode.Groups
             || _mode == ProxyInvocationMode.AllExcept
             || _mode == ProxyInvocationMode.Clients
             || _mode == ProxyInvocationMode.Others)

--- a/src/NexNet/Invocation/ServerSessionContext.cs
+++ b/src/NexNet/Invocation/ServerSessionContext.cs
@@ -30,7 +30,7 @@ public sealed class ServerSessionContext<TProxy> : SessionContext<TProxy>
     /// <param name="groupName">Group to add this session to.</param>
     public void AddToGroup(string groupName)
     {
-        Session!.SessionManager?.RegisterSessionGroup(groupName, Session);
+        Session.SessionManager?.RegisterSessionGroup(groupName, Session);
     }
 
 
@@ -40,7 +40,7 @@ public sealed class ServerSessionContext<TProxy> : SessionContext<TProxy>
     /// <param name="groupNames">Groups to add this session to.</param>
     public void AddToGroups(string[] groupNames)
     {
-        Session!.SessionManager?.RegisterSessionGroup(groupNames, Session);
+        Session.SessionManager?.RegisterSessionGroup(groupNames, Session);
     }
 
     /// <summary>
@@ -49,7 +49,7 @@ public sealed class ServerSessionContext<TProxy> : SessionContext<TProxy>
     /// <param name="groupName">Group to remove this session from.</param>
     public void RemoveFromGroup(string groupName)
     {
-        Session!.SessionManager?.UnregisterSessionGroup(groupName, Session);
+        Session.SessionManager?.UnregisterSessionGroup(groupName, Session);
     }
 
     internal override void Reset()
@@ -64,21 +64,34 @@ public sealed class ServerSessionContext<TProxy> : SessionContext<TProxy>
         private readonly Stack<TProxy> _instancedProxies = new Stack<TProxy>();
 
         private TProxy? _caller;
+
         public TProxy Caller
         {
-            get => _caller ??= _cacheManager.ProxyCache.Rent(_context.Session!,  ProxyInvocationMode.Caller, null);
+            get => _caller ??= _cacheManager.ProxyCache.Rent(
+                _context.Session,
+                _context.SessionManager,
+                ProxyInvocationMode.Caller,
+                null);
         }
 
         private TProxy? _all;
         public TProxy All
         {
-            get => _all ??= _cacheManager.ProxyCache.Rent(_context.Session!, ProxyInvocationMode.All, null);
+            get => _all ??= _cacheManager.ProxyCache.Rent(
+                _context.Session,
+                _context.SessionManager, 
+                ProxyInvocationMode.All, 
+                null);
         }
 
         private TProxy? _others;
         public TProxy Others
         {
-            get => _others ??= _cacheManager.ProxyCache.Rent(_context.Session!, ProxyInvocationMode.Others, null);
+            get => _others ??= _cacheManager.ProxyCache.Rent(
+                _context.Session,
+                _context.SessionManager, 
+                ProxyInvocationMode.Others,
+                null);
         }
 
 
@@ -92,7 +105,8 @@ public sealed class ServerSessionContext<TProxy> : SessionContext<TProxy>
         public TProxy Client(long id)
         {
             var proxy = _cacheManager.ProxyCache.Rent(
-                _context.Session!,
+                _context.Session,
+                _context.SessionManager,
                 ProxyInvocationMode.Client,
                 new[] { id });
             _instancedProxies.Push(proxy);
@@ -103,7 +117,8 @@ public sealed class ServerSessionContext<TProxy> : SessionContext<TProxy>
         public TProxy Clients(long[] ids)
         {
             var proxy = _cacheManager.ProxyCache.Rent(
-                _context.Session!,
+                _context.Session,
+                _context.SessionManager,
                 ProxyInvocationMode.Clients,
                 ids);
             _instancedProxies.Push(proxy);
@@ -114,7 +129,8 @@ public sealed class ServerSessionContext<TProxy> : SessionContext<TProxy>
         public TProxy Group(string groupName)
         {
             var proxy = _cacheManager.ProxyCache.Rent(
-                _context.Session!,
+                _context.Session,
+                _context.SessionManager,
                 ProxyInvocationMode.Groups,
                 new[] { groupName });
             _instancedProxies.Push(proxy);
@@ -125,7 +141,8 @@ public sealed class ServerSessionContext<TProxy> : SessionContext<TProxy>
         public TProxy Groups(string[] groupName)
         {
             var proxy = _cacheManager.ProxyCache.Rent(
-                _context.Session!,
+                _context.Session,
+                _context.SessionManager,
                 ProxyInvocationMode.Groups,
                 groupName);
             _instancedProxies.Push(proxy);

--- a/src/NexNet/Invocation/ServerSessionContext.cs
+++ b/src/NexNet/Invocation/ServerSessionContext.cs
@@ -18,8 +18,8 @@ public sealed class ServerSessionContext<TProxy> : SessionContext<TProxy>
     /// </summary>
     public IProxyClients<TProxy> Clients => _proxy;
 
-        internal ServerSessionContext(INexNetSession<TProxy> session)
-        : base(session)
+    internal ServerSessionContext(INexNetSession<TProxy> session, SessionManager sessionManager)
+        : base(session, sessionManager)
     {
         _proxy = new ClientProxy(session.CacheManager, this);
     }
@@ -66,7 +66,7 @@ public sealed class ServerSessionContext<TProxy> : SessionContext<TProxy>
         private TProxy? _caller;
         public TProxy Caller
         {
-            get => _caller ??= _cacheManager.ProxyCache.Rent(_context.Session!, ProxyInvocationMode.Caller, null);
+            get => _caller ??= _cacheManager.ProxyCache.Rent(_context.Session!,  ProxyInvocationMode.Caller, null);
         }
 
         private TProxy? _all;

--- a/src/NexNet/Invocation/ServerSessionContext.cs
+++ b/src/NexNet/Invocation/ServerSessionContext.cs
@@ -70,6 +70,7 @@ public sealed class ServerSessionContext<TProxy> : SessionContext<TProxy>
             get => _caller ??= _cacheManager.ProxyCache.Rent(
                 _context.Session,
                 _context.SessionManager,
+                _context.Session.CacheManager,
                 ProxyInvocationMode.Caller,
                 null);
         }
@@ -79,7 +80,8 @@ public sealed class ServerSessionContext<TProxy> : SessionContext<TProxy>
         {
             get => _all ??= _cacheManager.ProxyCache.Rent(
                 _context.Session,
-                _context.SessionManager, 
+                _context.SessionManager,
+                _context.Session.CacheManager,
                 ProxyInvocationMode.All, 
                 null);
         }
@@ -89,7 +91,8 @@ public sealed class ServerSessionContext<TProxy> : SessionContext<TProxy>
         {
             get => _others ??= _cacheManager.ProxyCache.Rent(
                 _context.Session,
-                _context.SessionManager, 
+                _context.SessionManager,
+                _context.Session.CacheManager,
                 ProxyInvocationMode.Others,
                 null);
         }
@@ -107,6 +110,7 @@ public sealed class ServerSessionContext<TProxy> : SessionContext<TProxy>
             var proxy = _cacheManager.ProxyCache.Rent(
                 _context.Session,
                 _context.SessionManager,
+                _context.Session.CacheManager,
                 ProxyInvocationMode.Client,
                 new[] { id });
             _instancedProxies.Push(proxy);
@@ -119,6 +123,7 @@ public sealed class ServerSessionContext<TProxy> : SessionContext<TProxy>
             var proxy = _cacheManager.ProxyCache.Rent(
                 _context.Session,
                 _context.SessionManager,
+                _context.Session.CacheManager,
                 ProxyInvocationMode.Clients,
                 ids);
             _instancedProxies.Push(proxy);
@@ -131,6 +136,7 @@ public sealed class ServerSessionContext<TProxy> : SessionContext<TProxy>
             var proxy = _cacheManager.ProxyCache.Rent(
                 _context.Session,
                 _context.SessionManager,
+                _context.Session.CacheManager,
                 ProxyInvocationMode.Groups,
                 new[] { groupName });
             _instancedProxies.Push(proxy);
@@ -143,6 +149,7 @@ public sealed class ServerSessionContext<TProxy> : SessionContext<TProxy>
             var proxy = _cacheManager.ProxyCache.Rent(
                 _context.Session,
                 _context.SessionManager,
+                _context.Session.CacheManager,
                 ProxyInvocationMode.Groups,
                 groupName);
             _instancedProxies.Push(proxy);

--- a/src/NexNet/Invocation/SessionContext.cs
+++ b/src/NexNet/Invocation/SessionContext.cs
@@ -12,7 +12,9 @@ public abstract class SessionContext<TProxy>
     where TProxy : ProxyInvocationBase, IProxyInvoker, new()
 {
     internal INexNetSession<TProxy> Session { get; }
+    internal SessionManager? SessionManager { get; }
     internal SessionCacheManager<TProxy> CacheManager => Session.CacheManager;
+
 
     /// <summary>
     /// Store for this session used to keep and pass variables for the lifetime of this session.
@@ -24,9 +26,10 @@ public abstract class SessionContext<TProxy>
     /// </summary>
     public long Id => Session.Id;
 
-    internal SessionContext(INexNetSession<TProxy> session)
+    internal SessionContext(INexNetSession<TProxy> session, SessionManager? sessionManager)
     {
         Session = session;
+        SessionManager = sessionManager;
     }
 
     /// <summary>

--- a/src/NexNet/Invocation/SessionManager.cs
+++ b/src/NexNet/Invocation/SessionManager.cs
@@ -1,19 +1,25 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using NexNet.Internals;
 
 namespace NexNet.Invocation;
-
+/// <summary>
+/// Manages all connected sessions to the server and their groupings.
+/// </summary>
 internal class SessionManager
 {
-    public readonly ConcurrentDictionary<long, INexNetSession> Sessions = new();
-
     private readonly ConcurrentDictionary<int, SessionGroup> _sessionGroups = new();
     private static int _idCounter = 0;
 
-    private ConcurrentDictionary<string, int> _groupIdDictionary = new();
+    private readonly ConcurrentDictionary<string, int> _groupIdDictionary = new();
+
+
+    public readonly ConcurrentDictionary<long, INexNetSession> Sessions = new();
+
+    public IReadOnlyDictionary<string, int> Groups => _groupIdDictionary;
 
     public bool RegisterSession(INexNetSession session)
     {

--- a/src/NexNet/NexNetClient.cs
+++ b/src/NexNet/NexNetClient.cs
@@ -89,7 +89,7 @@ public sealed class NexNetClient<TClientHub, TServerProxy> : IAsyncDisposable
             OnSent = OnSent
         };
         
-        Proxy.Configure(_session, ProxyInvocationMode.Caller, null);
+        Proxy.Configure(_session, null, ProxyInvocationMode.Caller, null);
 
         await _session.StartAsClient().ConfigureAwait(false);
     }

--- a/src/NexNet/NexNetServer.cs
+++ b/src/NexNet/NexNetServer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Threading;
 using NexNet.Messages;
 using NexNet.Transports;
@@ -14,7 +15,7 @@ namespace NexNet;
 /// </summary>
 /// <typeparam name="TServerHub">The hub which will be running locally on the server.</typeparam>
 /// <typeparam name="TClientProxy">Proxy used to invoke methods on remote hubs.</typeparam>
-public sealed class NexNetServer<TServerHub, TClientProxy>
+public sealed class NexNetServer<TServerHub, TClientProxy> : INexNetServer<TClientProxy>
     where TServerHub : ServerHubBase<TClientProxy>, IInvocationMethodHash
     where TClientProxy : ProxyInvocationBase, IProxyInvoker, IInvocationMethodHash, new()
 {
@@ -23,8 +24,14 @@ public sealed class NexNetServer<TServerHub, TClientProxy>
     private readonly ServerConfig _config;
     private readonly Func<TServerHub> _hubFactory;
     private readonly SessionCacheManager<TClientProxy> _cacheManager;
-
     private ITransportListener? _listener;
+    private readonly ConcurrentBag<ServerHubContext<TClientProxy>> _serverHubContextCache = new();
+
+    /// <summary>
+    /// Cache for all the server hub contexts.
+    /// </summary>
+    ConcurrentBag<ServerHubContext<TClientProxy>> INexNetServer<TClientProxy>.ServerHubContextCache =>
+        _serverHubContextCache;
 
     // ReSharper disable once StaticMemberInGenericType
     private static int _sessionIdIncrementor;
@@ -38,8 +45,6 @@ public sealed class NexNetServer<TServerHub, TClientProxy>
     /// Configurations the server us currently using.
     /// </summary>
     public ServerConfig Config => _config;
-
-    public ServerHubContext<TClientProxy> HubContext { get; }
 
     /// <summary>
     /// Creates a NexNetServer class for handling incoming connections.
@@ -55,7 +60,18 @@ public sealed class NexNetServer<TServerHub, TClientProxy>
 
         _watchdogTimer = new Timer(ConnectionWatchdog);
 
-        HubContext = new ServerHubContext<TClientProxy>();
+    }
+
+    /// <summary>
+    /// Gets a hub context which can be used outside of the hub.  Dispose after usage.
+    /// </summary>
+    /// <returns>Server hub context for invocation of client methods.</returns>
+    public ServerHubContext<TClientProxy> GetContext()
+    {
+        if(!_serverHubContextCache.TryTake(out var context))
+            context = new ServerHubContext<TClientProxy>(this, _sessionManager, _cacheManager);
+
+        return context;
     }
 
     /// <summary>

--- a/src/NexNet/NexNetServer.cs
+++ b/src/NexNet/NexNetServer.cs
@@ -39,6 +39,8 @@ public sealed class NexNetServer<TServerHub, TClientProxy>
     /// </summary>
     public ServerConfig Config => _config;
 
+    public ServerHubContext<TClientProxy> HubContext { get; }
+
     /// <summary>
     /// Creates a NexNetServer class for handling incoming connections.
     /// </summary>
@@ -52,6 +54,8 @@ public sealed class NexNetServer<TServerHub, TClientProxy>
         _cacheManager = new SessionCacheManager<TClientProxy>();
 
         _watchdogTimer = new Timer(ConnectionWatchdog);
+
+        HubContext = new ServerHubContext<TClientProxy>();
     }
 
     /// <summary>

--- a/src/NexNet/NexNetSession.cs
+++ b/src/NexNet/NexNetSession.cs
@@ -77,8 +77,8 @@ internal class NexNetSession<THub, TProxy> : INexNetSession<TProxy>
         _isServer = configurations.IsServer;
         _hub = configurations.Hub;
         _hub.SessionContext = configurations.IsServer
-            ? new ServerSessionContext<TProxy>(this)
-            : new ClientSessionContext<TProxy>(this);
+            ? new ServerSessionContext<TProxy>(this, _sessionManager!)
+            : new ClientSessionContext<TProxy>(this, _sessionManager);
 
         SessionInvocationStateManager = new SessionInvocationStateManager(configurations.Cache);
         SessionStore = new SessionStore();

--- a/src/NexNet/NexNetSession.cs
+++ b/src/NexNet/NexNetSession.cs
@@ -497,6 +497,7 @@ internal class NexNetSession<THub, TProxy> : INexNetSession<TProxy>
                 {
                     session._invocationSemaphore.Release();
 
+                    // Clear out the references before returning to the pool.
                     arguments.Session = null!;
                     arguments.Message = null!;
                     session._invocationTaskArgumentsPool.Add(arguments);

--- a/src/NexNet/NexNetSession.cs
+++ b/src/NexNet/NexNetSession.cs
@@ -669,6 +669,8 @@ internal class NexNetSession<THub, TProxy> : INexNetSession<TProxy>
         _hub.Disconnected(reason);
         OnDisconnected?.Invoke();
 
+        _hub.SessionContext.Reset();
+
         _sessionManager?.UnregisterSession(this);
         ((IDisposable)SessionStore).Dispose();
         _invocationTaskArgumentsPool.Clear();

--- a/src/NexNet/NexNetSession.cs
+++ b/src/NexNet/NexNetSession.cs
@@ -78,7 +78,7 @@ internal class NexNetSession<THub, TProxy> : INexNetSession<TProxy>
         _hub = configurations.Hub;
         _hub.SessionContext = configurations.IsServer
             ? new ServerSessionContext<TProxy>(this, _sessionManager!)
-            : new ClientSessionContext<TProxy>(this, _sessionManager);
+            : new ClientSessionContext<TProxy>(this);
 
         SessionInvocationStateManager = new SessionInvocationStateManager(configurations.Cache);
         SessionStore = new SessionStore();

--- a/src/NexNetDemo/Program.cs
+++ b/src/NexNetDemo/Program.cs
@@ -45,7 +45,7 @@ partial class ClientHub
     private int i = 0;
     public void Update()
     {
-        //Console.WriteLine("ClientHub Update called and invoked properly.");
+        Console.WriteLine("ClientHub Update called and invoked properly.");
     }
 
     public ValueTask<int> GetTask()
@@ -55,11 +55,13 @@ partial class ClientHub
     }
     public ValueTask<int> GetTaskAgain()
     {
+        Console.WriteLine("GetTaskAgain");
         return ValueTask.FromResult(Interlocked.Increment(ref i));
     }
 
     protected override async ValueTask OnConnected(bool isReconnected)
     {
+        return;
         for (int j = 0; j < 1000000; j++)
         {
   
@@ -312,6 +314,13 @@ internal class Program
             //Console.WriteLine(e);
             throw;
         }
+
+        await Task.Delay(100);
+        using var s = server.GetContext();
+
+        var id = s.GetClientIds().First();
+        //var s5 = await s.Clients.Client(id).GetTaskAgain();
+        var s54 = await s.Clients.Clients(new[] { id }).GetTaskAgain();
 
         Console.ReadLine();
         


### PR DESCRIPTION
The server needs to be able to send messages to clients connected from outside the hub itself.  This adds a public method `GetContext` on the server class to acquire an external hub context.  This external context will need to be disposes upon completion.

Added new tests for invocations.