### PR TITLE
ReadyTask & DisconnectedTask Null Reference Fix

### DIFF
--- a/src/NexNet/Internals/NexNetSessionConfigurations.cs
+++ b/src/NexNet/Internals/NexNetSessionConfigurations.cs
@@ -1,4 +1,5 @@
-﻿using NexNet.Cache;
+﻿using System.Threading.Tasks;
+using NexNet.Cache;
 using NexNet.Invocation;
 using NexNet.Transports;
 
@@ -21,4 +22,6 @@ internal readonly struct NexNetSessionConfigurations<THub, TProxy>
     public required long Id { get; init; }
 
     public required THub Hub { get; init; }
+    public TaskCompletionSource? ReadyTaskCompletionSource { get; init; }
+    public TaskCompletionSource? DisconnectedTaskCompletionSource { get; init; }
 }


### PR DESCRIPTION
Fixed issue where sessions would not be instanced prior to the completion of the ConnectAsync invocation and would cause null reference exception on the ReadyTask await call.  Fixed same issue with DisconnectedTask as well.