### PR TITLE
Channel Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ NexNet has a limitation where the total arguments passed can't exceed 65,535 byt
 ## Channels
 Building upon the Duplex Pipes infrastructure, NexNet prvoides two channel structures to allow transmission/streaming of data structures via the `INexusDuplexChannel<T>` and `INexusDuplexUnmanagedChannel<T>` interfaces.
 
+Several extension methods have been provided to allow for ease of reading and writing of entire collections (eg. selected table rows).
+- `NexusChannelExtensions.WriteAndComplete<T>(...)`: Writing a collection to either a `INexusDuplexChannel<T>` or `INexusChannelWriter<T>` with optional batch sizes for optimized sending.
+- `NexusChannelExtensions.ReadUntilComplete<T>(...)`: Reads from either a `INexusDuplexChannel<T>` or a `INexusChannelReader<T>` with an optional initial collection size to reduce collection resizing.
+
 #### INexusDuplexChannel<T>
 The `INexusDuplexChannel<T>` interface provides data transmission for all types which can be seralized by [MemoryPack](https://github.com/Cysharp/MemoryPack#built-in-supported-types).  This is the interface tuned for general usage and varying sized payloads.  If you have an [unmanaged types](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/unmanaged-types) to send, make sure to use the  `INexusDuplexUnmanagedChannel<T>` interface instead as it is fine tuned for performance of those simple types
 

--- a/src/NexNet.IntegrationTests/Pipes/NexusChannelReaderTests.cs
+++ b/src/NexNet.IntegrationTests/Pipes/NexusChannelReaderTests.cs
@@ -67,8 +67,7 @@ internal class NexusChannelReaderTests
             await pipeReader.BufferData(buffer).Timeout(1);
         }
 
-
-        var result = await reader.ReadAsync(CancellationToken.None).Timeout(10000);
+        var result = await reader.ReadAsync(CancellationToken.None).Timeout(1);
 
         Assert.AreEqual(baseObject, result.Single());
 
@@ -118,7 +117,7 @@ internal class NexusChannelReaderTests
         var pipeReader = new NexusPipeReader(new DummyPipeStateManager());
         var reader = new NexusChannelReader<ComplexMessage>(pipeReader);
         // ReSharper disable once MethodHasAsyncOverload
-        pipeReader.Complete();
+        await pipeReader.CompleteAsync();
         var result = await reader.ReadAsync().Timeout(1);
 
         Assert.IsTrue(reader.IsComplete);

--- a/src/NexNet.IntegrationTests/Pipes/NexusChannelReaderUnmanagedTests.cs
+++ b/src/NexNet.IntegrationTests/Pipes/NexusChannelReaderUnmanagedTests.cs
@@ -63,7 +63,7 @@ internal class NexusChannelReaderUnmanagedTests
         var reader = new NexusChannelReaderUnmanaged<long>(pipeReader);
 
         // ReSharper disable once MethodHasAsyncOverload
-        pipeReader.Complete();
+        await pipeReader.CompleteAsync();
         var result = await reader.ReadAsync().Timeout(1);
 
         Assert.IsTrue(reader.IsComplete);

--- a/src/NexNet.IntegrationTests/Pipes/NexusChannelReaderWriterTests.cs
+++ b/src/NexNet.IntegrationTests/Pipes/NexusChannelReaderWriterTests.cs
@@ -72,7 +72,23 @@ internal class NexusChannelReaderWriterTests
         }).Timeout(1);
 
         Assert.AreEqual(iterations, count);
+    }
 
+    [Test]
+    public async Task ReaderCompletesOnPartialRead()
+    {
+        var (writer, reader) = GetReaderWriter<long>();
+        var value = ComplexMessage.Random();
+
+        _ = Task.Run(async () =>
+        {
+            await writer.Writer.WriteAsync(new ReadOnlyMemory<byte>(new byte[] { 1, 2, 3, 4 }));
+            await reader.Reader.CompleteAsync();
+        });
+        
+        var completeRead = await reader.ReadUntilComplete();
+
+        Assert.AreEqual(0, completeRead.Count);
     }
     private (NexusChannelWriter<T>, NexusChannelReader<T>) GetReaderWriter<T>()
     {

--- a/src/NexNet.IntegrationTests/Pipes/NexusChannelReaderWriterUnmanagedTests.cs
+++ b/src/NexNet.IntegrationTests/Pipes/NexusChannelReaderWriterUnmanagedTests.cs
@@ -74,6 +74,20 @@ internal class NexusChannelReaderWriterUnmanagedTests
 
     }
 
+    [Test]
+    public async Task ReaderCompletesOnPartialRead()
+    {
+        var (writer, reader) = GetReaderWriter<long>();
+        var value = ComplexMessage.Random();
+
+        await writer.Writer.WriteAsync(new ReadOnlyMemory<byte>(new byte[] { 1, 2, 3, 4 })).Timeout(1);
+        await reader.Reader.CompleteAsync();
+
+        var completeRead = await reader.ReadUntilComplete().Timeout(1);
+
+        Assert.AreEqual(0, completeRead.Count);
+    }
+
     private (NexusChannelWriterUnmanaged<T>, NexusChannelReaderUnmanaged<T>) GetReaderWriter<T>()
         where T : unmanaged
     {

--- a/src/NexNet.IntegrationTests/Pipes/NexusDuplexPipeReaderTests.cs
+++ b/src/NexNet.IntegrationTests/Pipes/NexusDuplexPipeReaderTests.cs
@@ -461,7 +461,7 @@ internal class NexusDuplexPipeReaderTests
     public void TryReadReturnsTrueWhenCompleted()
     {
         var reader = CreateReader();
-        reader.Complete();
+        reader.CompleteNoNotify();
         Assert.IsTrue(reader.TryRead(out var readData));
         Assert.IsFalse(readData.IsCanceled);
         Assert.IsTrue(readData.IsCompleted);

--- a/src/NexNet.props
+++ b/src/NexNet.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.3.0</Version>
+    <Version>0.3.1</Version>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <TargetFramework>net7.0</TargetFramework>

--- a/src/NexNet/Pipes/INexusChannelReader.cs
+++ b/src/NexNet/Pipes/INexusChannelReader.cs
@@ -29,5 +29,5 @@ public interface INexusChannelReader<T> : IDisposable
     /// A task that represents the asynchronous read operation. The value of the TResult parameter contains an enumerable collection of type T.
     /// If the read operation is completed or canceled, the returned task will contain an empty collection.
     /// </returns>
-    ValueTask<IEnumerable<T>> ReadAsync(CancellationToken cancellationToken = default);
+    ValueTask<IReadOnlyList<T>> ReadAsync(CancellationToken cancellationToken = default);
 }

--- a/src/NexNet/Pipes/INexusChannelReader.cs
+++ b/src/NexNet/Pipes/INexusChannelReader.cs
@@ -17,6 +17,11 @@ public interface INexusChannelReader<T> : IDisposable
     bool IsComplete { get; }
 
     /// <summary>
+    /// Gets a value indicating the number of bytes that are currently buffered in the underlying INexusPipeWriter.
+    /// </summary>
+    long BufferedLength { get; }
+
+    /// <summary>
     /// Asynchronously reads data from the duplex pipe.
     /// </summary>
     /// <param name="cancellationToken"></param>

--- a/src/NexNet/Pipes/INexusChannelWriter.cs
+++ b/src/NexNet/Pipes/INexusChannelWriter.cs
@@ -30,4 +30,10 @@ public interface INexusChannelWriter<in T>
     /// <param name="cancellationToken">An optional CancellationToken to observe while waiting for the task to complete.</param>
     /// <returns>A ValueTask that represents the asynchronous write operation. The task result contains a boolean value that indicates whether the write operation was successful. Returns false if the operation is canceled or the pipe writer is completed.</returns>
     ValueTask<bool> WriteAsync(IEnumerable<T> items, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Marks the channel writer as complete, indicating that no more items will be written to it.
+    /// </summary>
+    /// <returns>A ValueTask that represents the asynchronous operation of marking the channel writer as complete.</returns>
+    public ValueTask CompleteAsync();
 }

--- a/src/NexNet/Pipes/NexusChannelExtensions.cs
+++ b/src/NexNet/Pipes/NexusChannelExtensions.cs
@@ -71,9 +71,13 @@ public static class NexusChannelExtensions
     {
         using var reader = await channel.GetReaderAsync();
         var list = new List<T>(estimatedSize);
-        while (reader.IsComplete == false)
+        while (true)
         {
-            list.AddRange(await reader.ReadAsync(cancellationToken))
+            if(reader.IsComplete && reader.BufferedLength == 0)
+                break;
+
+            var readResult = await reader.ReadAsync(cancellationToken);
+            list.AddRange(readResult);
         }
 
         return list;

--- a/src/NexNet/Pipes/NexusChannelExtensions.cs
+++ b/src/NexNet/Pipes/NexusChannelExtensions.cs
@@ -12,7 +12,6 @@ namespace NexNet.Pipes;
 /// </summary>
 public static class NexusChannelExtensions
 {
-
     /// <summary>
     /// Writes the provided data to the given duplex channel in optional chunks and completes the channel.
     /// </summary>
@@ -26,7 +25,7 @@ public static class NexusChannelExtensions
     public static async ValueTask WriteAndComplete<T>(
         this INexusDuplexChannel<T> channel,
         IEnumerable<T> enumerableData,
-        int chunkSize = 1,
+        int chunkSize = 10,
         CancellationToken cancellationToken = default)
     {
         var writer = await channel.GetWriterAsync();
@@ -46,7 +45,7 @@ public static class NexusChannelExtensions
     public static async ValueTask WriteAndComplete<T>(
         this INexusChannelWriter<T> writer,
         IEnumerable<T> enumerableData,
-        int chunkSize = 1,
+        int chunkSize = 10,
         CancellationToken cancellationToken = default)
     {
         // If the chunk size is greater than 1, split the data into chunks and write them to the channel

--- a/src/NexNet/Pipes/NexusChannelExtensions.cs
+++ b/src/NexNet/Pipes/NexusChannelExtensions.cs
@@ -1,0 +1,82 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NexNet.Pipes;
+
+/// <summary>
+/// Provides extension methods for the INexusDuplexChannel interface.
+/// These methods provide functionality for writing to and reading from duplex channels.
+/// </summary>
+public static class NexusChannelExtensions
+{
+
+    /// <summary>
+    /// Writes the provided data to the given duplex channel in optional chunks and completes the channel.
+    /// </summary>
+    /// <typeparam name="T">The type of the data that can be transmitted through the channel.</typeparam>
+    /// <param name="channel">The duplex channel to which the data will be written.</param>
+    /// <param name="enumerableData">The data to be written to the channel.</param>
+    /// <param name="chunkSize">The size of the chunks to be written to the channel.</param>
+    /// <param name="cancellationToken">An optional CancellationToken to observe while waiting for the task to complete.</param>
+    /// <returns>A ValueTask that represents the asynchronous write and complete operation.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static async ValueTask WriteAndComplete<T>(
+        this INexusDuplexChannel<T> channel,
+        IEnumerable<T> enumerableData,
+        int chunkSize = 1,
+        CancellationToken cancellationToken = default)
+    {
+        var writer = await channel.GetWriterAsync();
+
+        // If the chunk size is greater than 1, split the data into chunks and write them to the channel
+        // otherwise write the data to the channel as is.
+        if (chunkSize > 1)
+        {
+            var dataChunks = enumerableData.Chunk(chunkSize);
+
+            foreach (var chunk in dataChunks)
+            {
+                await writer.WriteAsync(chunk, cancellationToken);
+            }
+        }
+        else
+        {
+            foreach (var data in enumerableData)
+            {
+                await writer.WriteAsync(data, cancellationToken);
+            }
+
+        }
+
+        await channel.CompleteAsync();
+    }
+
+
+    /// <summary>
+    /// Reads data from the given duplex channel until the channel is complete and returns a list with read data.
+    /// </summary>
+    /// <typeparam name="T">The type of the data that can be transmitted through the channel.</typeparam>
+    /// <param name="channel">The duplex channel from which the data will be read.</param>
+    /// <param name="estimatedSize">An optional parameter to set the initial capacity of the list that will store the read data.</param>
+    /// <param name="cancellationToken">An optional CancellationToken to observe while waiting for the task to complete.</param>
+    /// <returns>A ValueTask that represents the asynchronous read operation. The task result contains a List of type T with the data read from the channel.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static async ValueTask<List<T>> ReadUntilComplete<T>(
+        this INexusDuplexChannel<T> channel,
+        int estimatedSize = 0,
+        CancellationToken cancellationToken = default)
+    {
+        using var reader = await channel.GetReaderAsync();
+        var list = new List<T>(estimatedSize);
+        while (reader.IsComplete == false)
+        {
+            list.AddRange(await reader.ReadAsync(cancellationToken))
+        }
+
+        return list;
+    }
+
+}

--- a/src/NexNet/Pipes/NexusChannelReader.cs
+++ b/src/NexNet/Pipes/NexusChannelReader.cs
@@ -20,10 +20,11 @@ internal class NexusChannelReader<T> : INexusChannelReader<T>
     internal readonly NexusPipeReader Reader;
     internal List<T>? List;
 
-    /// <summary>
-    /// Gets a value indicating whether the reading operation from the duplex pipe is complete.
-    /// </summary>
+    /// <inheritdoc/>
     public bool IsComplete { get; protected set; }
+
+    /// <inheritdoc/>
+    public long BufferedLength => Reader.BufferedLength;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="NexusChannelReaderUnmanaged{T}"/> class using the specified <see cref="INexusDuplexPipe"/>.
@@ -43,14 +44,7 @@ internal class NexusChannelReader<T> : INexusChannelReader<T>
         List = new List<T>();
     }
 
-    /// <summary>
-    /// Asynchronously reads data from the duplex pipe.
-    /// </summary>
-    /// <param name="cancellationToken"></param>
-    /// <returns>
-    /// A task that represents the asynchronous read operation. The value of the TResult parameter contains an enumerable collection of type T.
-    /// If the read operation is completed or canceled, the returned task will contain an empty collection.
-    /// </returns>
+    /// <inheritdoc/>
     public virtual async ValueTask<IEnumerable<T>> ReadAsync(CancellationToken cancellationToken = default)
     {
         if(IsComplete)
@@ -64,7 +58,7 @@ internal class NexusChannelReader<T> : INexusChannelReader<T>
             var result = await Reader.ReadAsync(cancellationToken).ConfigureAwait(false);
 
             // Check if the result is completed or canceled.
-            if (result.IsCompleted)
+            if (result.IsCompleted && Reader.BufferedLength == 0)
             {
                 IsComplete = true;
                 return Enumerable.Empty<T>();

--- a/src/NexNet/Pipes/NexusChannelReader.cs
+++ b/src/NexNet/Pipes/NexusChannelReader.cs
@@ -21,10 +21,12 @@ internal class NexusChannelReader<T> : INexusChannelReader<T>
     internal List<T>? List;
 
     /// <inheritdoc/>
-    public bool IsComplete { get; protected set; }
+    public bool IsComplete => Reader.IsCompleted;
 
     /// <inheritdoc/>
     public long BufferedLength => Reader.BufferedLength;
+
+    protected static readonly List<T> EmptyList = new List<T>(0);
 
     /// <summary>
     /// Initializes a new instance of the <see cref="NexusChannelReaderUnmanaged{T}"/> class using the specified <see cref="INexusDuplexPipe"/>.
@@ -45,10 +47,10 @@ internal class NexusChannelReader<T> : INexusChannelReader<T>
     }
 
     /// <inheritdoc/>
-    public virtual async ValueTask<IEnumerable<T>> ReadAsync(CancellationToken cancellationToken = default)
+    public virtual async ValueTask<IReadOnlyList<T>> ReadAsync(CancellationToken cancellationToken = default)
     {
-        if(IsComplete)
-            return Enumerable.Empty<T>();
+        if (IsComplete && BufferedLength == 0)
+            return EmptyList;
 
         List?.Clear();
 
@@ -58,16 +60,16 @@ internal class NexusChannelReader<T> : INexusChannelReader<T>
             var result = await Reader.ReadAsync(cancellationToken).ConfigureAwait(false);
 
             // Check if the result is completed or canceled.
-            if (result.IsCompleted && Reader.BufferedLength == 0)
-            {
-                IsComplete = true;
-                return Enumerable.Empty<T>();
-            }
+            if (result.IsCompleted && result.Buffer.Length == 0)
+                return EmptyList;
 
             if (result.IsCanceled)
-                return Enumerable.Empty<T>();
+                return EmptyList;
 
-            Read(result.Buffer, Reader, List!);
+            var readAmount = Read(result.Buffer, Reader, List!);
+
+            if (result.IsCompleted && readAmount == 0)
+                return EmptyList;
 
             if(List!.Count == 0)
                 continue;
@@ -83,7 +85,7 @@ internal class NexusChannelReader<T> : INexusChannelReader<T>
     /// <param name="pipeReader">The pipe reader used to advance the buffer after reading.</param>
     /// <param name="list">The list used to store the data.</param>
     /// <returns>An enumerable collection of type T.</returns>
-    private static void Read(ReadOnlySequence<byte> buffer, NexusPipeReader pipeReader, List<T> list)
+    private static int Read(ReadOnlySequence<byte> buffer, NexusPipeReader pipeReader, List<T> list)
     {
         var length = buffer.Length;
         
@@ -107,6 +109,8 @@ internal class NexusChannelReader<T> : INexusChannelReader<T>
         {
             pipeReader.AdvanceTo(successfulConsumedCount);
         }
+
+        return successfulConsumedCount;
     }
 
     /// <summary>

--- a/src/NexNet/Pipes/NexusChannelWriter.cs
+++ b/src/NexNet/Pipes/NexusChannelWriter.cs
@@ -82,6 +82,12 @@ internal class NexusChannelWriter<T> : INexusChannelWriter<T>
         return true;
     }
 
+    /// <inheritdoc />
+    public ValueTask CompleteAsync()
+    {
+        return Writer.CompleteAsync();
+    }
+
 
     private static void Write(ref T item, ref NexusPipeWriter nexusPipeWriter)
     {

--- a/src/NexNet/Pipes/NexusDuplexPipe.cs
+++ b/src/NexNet/Pipes/NexusDuplexPipe.cs
@@ -310,7 +310,7 @@ internal class NexusDuplexPipe : INexusDuplexPipe, IPipeStateManager
             else
             {
                 // Close input pipe.
-                _inputPipeReader.Complete();
+                _inputPipeReader.CompleteNoNotify();
             }
         }
 
@@ -319,7 +319,7 @@ internal class NexusDuplexPipe : INexusDuplexPipe, IPipeStateManager
             if (_session.IsServer)
             {
                 // Close input pipe.
-                _inputPipeReader.Complete();
+                _inputPipeReader.CompleteNoNotify();
             }
             else
             {

--- a/src/NexNet/Pipes/NexusPipeReader.cs
+++ b/src/NexNet/Pipes/NexusPipeReader.cs
@@ -199,20 +199,28 @@ internal class NexusPipeReader : PipeReader
     {
         if (_isCompleted)
         {
-            result = new ReadResult(ReadOnlySequence<byte>.Empty, false, _isCompleted);
+            // There can still be data the buffer even if the pipe is completed.
+            lock (_buffer)
+            {
+                result = new ReadResult(_buffer.GetBuffer(), false, _isCompleted);
+            }
             return true;
         }
 
         if (_isCanceled)
         {
             _isCanceled = false;
-            result = new ReadResult(ReadOnlySequence<byte>.Empty, true, _isCompleted);
+            // There can still be data the buffer even if the pipe is canceled.
+            lock (_buffer)
+            {
+                result =  new ReadResult(_buffer.GetBuffer(), true, _isCompleted);
+            }
             return true;
         }
         
         lock (_buffer)
         {
-            if (_buffer.Length == 0)
+            if (BufferedLength == 0)
             {
                 result = new ReadResult(ReadOnlySequence<byte>.Empty, false, _isCompleted);
                 return false;
@@ -228,16 +236,31 @@ internal class NexusPipeReader : PipeReader
     public override async ValueTask<ReadResult> ReadAsync(CancellationToken cancellationToken = new CancellationToken())
     {
         if (_isCompleted)
-            return new ReadResult(ReadOnlySequence<byte>.Empty, false, _isCompleted);
+        {
+            // There can still be data the buffer even if the pipe is completed.
+            lock (_buffer)
+            {
+                return new ReadResult(_buffer.GetBuffer(), false, _isCompleted);
+            }
+        }
 
         if (cancellationToken.IsCancellationRequested)
-            return new ReadResult(ReadOnlySequence<byte>.Empty, true, _isCompleted);
+        {
+            // There can still be data the buffer even if the pipe is canceled.
+            lock (_buffer)
+            {
+                return new ReadResult(_buffer.GetBuffer(), true, _isCompleted);
+            }
+        }
 
         if (_isCanceled)
         {
             _isCanceled = false;
-            var result = new ReadResult(ReadOnlySequence<byte>.Empty, true, _isCompleted);
-            return result;
+            // There can still be data the buffer even if the pipe is canceled.
+            lock (_buffer)
+            {
+                return new ReadResult(_buffer.GetBuffer(), true, _isCompleted);
+            }
         }
 
         CancellationTokenRegistration? cts = null;
@@ -263,7 +286,11 @@ internal class NexusPipeReader : PipeReader
             }
             catch (OperationCanceledException)
             {
-                return new ReadResult(ReadOnlySequence<byte>.Empty, true, _isCompleted);
+                // There can still be data the buffer even if the pipe is canceled.
+                lock (_buffer)
+                {
+                    return new ReadResult(_buffer.GetBuffer(), true, _isCompleted);
+                }
             }
             finally
             {
@@ -280,12 +307,22 @@ internal class NexusPipeReader : PipeReader
 
         // Check again for common cases.
         if (_isCompleted)
-            return new ReadResult(ReadOnlySequence<byte>.Empty, _isCanceled, _isCompleted);
+        {
+            // There can still be data the buffer even if the pipe is completed.
+            lock (_buffer)
+            {
+                return new ReadResult(_buffer.GetBuffer(), false, _isCompleted);
+            }
+        }
 
         if (_isCanceled)
         {
             _isCanceled = false;
-            return new ReadResult(ReadOnlySequence<byte>.Empty, true, _isCompleted);
+            // There can still be data the buffer even if the pipe is canceled.
+            lock (_buffer)
+            {
+                return new ReadResult(_buffer.GetBuffer(), true, _isCompleted);
+            }
         }
 
         ReadOnlySequence<byte> readOnlySequence;
@@ -298,7 +335,9 @@ internal class NexusPipeReader : PipeReader
 
         // If we currently have back pressure, and the buffer length is below the low water mark, then we need to
         // notify the other side that we are ready to receive more data.
-        if (_lowWaterMark != 0
+        // ignore the back pressure if the completed flag is set.
+        if (_isCompleted == false
+            && _lowWaterMark != 0
             && _stateManager.CurrentState.HasFlag(_backPressureFlag) 
             && bufferLength <= _lowWaterMark)
         {
@@ -311,8 +350,6 @@ internal class NexusPipeReader : PipeReader
                 // Set the task completion source to allow the next write to continue then assign a new one.
                 //_allowBuffer.TrySetResult();
             }
-
-
         }
 
         return new ReadResult(readOnlySequence, cancellationToken.IsCancellationRequested, _isCompleted);

--- a/src/NexNetDemo/Program.cs
+++ b/src/NexNetDemo/Program.cs
@@ -15,7 +15,8 @@ internal class Program
         //await new DuplexPipeStreamingSample(SampleBase.TransportMode.Quic).DuplexStreamingSample();
         //await new ChannelSample(SampleBase.TransportMode.Uds).UnmanagedChannelSample();
         //await new ChannelSample(SampleBase.TransportMode.Uds).ChannelStructSample();
-        await new ChannelSample(SampleBase.TransportMode.Uds).ClassSample();
+        //await new ChannelSample(SampleBase.TransportMode.Uds).ClassSample();
+        await new ChannelSample(SampleBase.TransportMode.Uds).ClassChannelBatchSample();
         //await new DuplexPipeStreamingSample().DuplexStreamingSample();
         //await new InvocationSample().UpdateInfo();
 

--- a/src/NexNetDemo/Samples/Channel/ChannelSample.cs
+++ b/src/NexNetDemo/Samples/Channel/ChannelSample.cs
@@ -2,6 +2,7 @@
 using System.Net.Security;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
+using NexNet;
 using NexNet.Pipes;
 using NexNet.Quic;
 
@@ -17,11 +18,7 @@ public class ChannelSample : SampleBase
 
     public async Task UnmanagedChannelSample()
     {
-        var server = ChannelSampleServerNexus.CreateServer(ServerConfig, () => new ChannelSampleServerNexus());
-        await server.StartAsync();
-
-        var client = ChannelSampleClientNexus.CreateClient(ClientConfig, new ChannelSampleClientNexus());
-        await client.ConnectAsync();
+        var(server, client) = await Setup();
 
         await using var channel = client.CreateUnmanagedChannel<int>();
 
@@ -40,11 +37,7 @@ public class ChannelSample : SampleBase
 
     public async Task ChannelStructSample()
     {
-        var server = ChannelSampleServerNexus.CreateServer(ServerConfig, () => new ChannelSampleServerNexus());
-        await server.StartAsync();
-
-        var client = ChannelSampleClientNexus.CreateClient(ClientConfig, new ChannelSampleClientNexus());
-        await client.ConnectAsync();
+        var (server, client) = await Setup();
 
         await using var pipe = client.CreateUnmanagedChannel<ChannelSampleStruct>();
 
@@ -63,11 +56,7 @@ public class ChannelSample : SampleBase
 
     public async Task ClassSample()
     {
-        var server = ChannelSampleServerNexus.CreateServer(ServerConfig, () => new ChannelSampleServerNexus());
-        await server.StartAsync();
-
-        var client = ChannelSampleClientNexus.CreateClient(ClientConfig, new ChannelSampleClientNexus());
-        await client.ConnectAsync();
+        var (server, client) = await Setup();
 
         await using var pipe = client.CreateChannel<ComplexMessage>();
 
@@ -84,5 +73,26 @@ public class ChannelSample : SampleBase
         }
     }
 
+    public async Task ClassChannelBatchSample()
+    {
+        var (server, client) = await Setup();
+
+        await using var pipe = client.CreateChannel<ComplexMessage>();
+
+        await client.Proxy.ClassChannelBatch(pipe);
+
+        var result = await pipe.ReadUntilComplete(100);
+    }
+
+    private async Task<(NexusServer<ChannelSampleServerNexus, ChannelSampleServerNexus.ClientProxy> server, NexusClient<ChannelSampleClientNexus, ChannelSampleClientNexus.ServerProxy> client)> Setup()
+    {
+        var server = ChannelSampleServerNexus.CreateServer(ServerConfig, () => new ChannelSampleServerNexus());
+        await server.StartAsync();
+
+        var client = ChannelSampleClientNexus.CreateClient(ClientConfig, new ChannelSampleClientNexus());
+        await client.ConnectAsync();
+
+        return (server, client);
+    }
 
 }

--- a/src/NexNetDemo/Samples/Channel/ChannelSample.cs
+++ b/src/NexNetDemo/Samples/Channel/ChannelSample.cs
@@ -11,7 +11,7 @@ namespace NexNetDemo.Samples.Channel;
 public class ChannelSample : SampleBase
 {
     public ChannelSample(TransportMode transportMode = TransportMode.Uds)
-        : base(false, transportMode)
+        : base(true, transportMode)
     {
 
     }
@@ -81,7 +81,7 @@ public class ChannelSample : SampleBase
 
         await client.Proxy.ClassChannelBatch(pipe);
 
-        var result = await pipe.ReadUntilComplete(100);
+        var result = await pipe.ReadUntilComplete(10000);
     }
 
     private async Task<(NexusServer<ChannelSampleServerNexus, ChannelSampleServerNexus.ClientProxy> server, NexusClient<ChannelSampleClientNexus, ChannelSampleClientNexus.ServerProxy> client)> Setup()

--- a/src/NexNetDemo/Samples/Channel/ChannelSample.cs
+++ b/src/NexNetDemo/Samples/Channel/ChannelSample.cs
@@ -11,7 +11,7 @@ namespace NexNetDemo.Samples.Channel;
 public class ChannelSample : SampleBase
 {
     public ChannelSample(TransportMode transportMode = TransportMode.Uds)
-        : base(true, transportMode)
+        : base(false, transportMode)
     {
 
     }
@@ -81,7 +81,7 @@ public class ChannelSample : SampleBase
 
         await client.Proxy.ClassChannelBatch(pipe);
 
-        var result = await pipe.ReadUntilComplete(10000);
+        var result = await pipe.ReadUntilComplete(1000);
     }
 
     private async Task<(NexusServer<ChannelSampleServerNexus, ChannelSampleServerNexus.ClientProxy> server, NexusClient<ChannelSampleClientNexus, ChannelSampleClientNexus.ServerProxy> client)> Setup()

--- a/src/NexNetDemo/Samples/Channel/ChannelSampleNexuses.cs
+++ b/src/NexNetDemo/Samples/Channel/ChannelSampleNexuses.cs
@@ -61,14 +61,14 @@ partial class ChannelSampleServerNexus
             await writer.WriteAsync(ComplexMessage.Random());
             await Task.Delay(10);
 
-            if (count++ > 100)
+            if (++count >= 100)
                 return;
         }
     }
 
     public async ValueTask ClassChannelBatch(INexusDuplexChannel<ComplexMessage> channel)
     {
-        await channel.WriteAndComplete(GetComplexMessages(), 100);
+        await channel.WriteAndComplete(GetComplexMessages(), 10);
     }
 
     private static IEnumerable<ComplexMessage> GetComplexMessages()
@@ -77,7 +77,7 @@ partial class ChannelSampleServerNexus
         while (true)
         {
             yield return ComplexMessage.Random();
-            if (count++ > 1000)
+            if (++count >= 10000)
                 yield break;
         }
     }

--- a/src/NexNetDemo/Samples/Channel/ChannelSampleNexuses.cs
+++ b/src/NexNetDemo/Samples/Channel/ChannelSampleNexuses.cs
@@ -68,7 +68,7 @@ partial class ChannelSampleServerNexus
 
     public async ValueTask ClassChannelBatch(INexusDuplexChannel<ComplexMessage> channel)
     {
-        await channel.WriteAndComplete(GetComplexMessages(), 10);
+        await channel.WriteAndComplete(GetComplexMessages());
     }
 
     private static IEnumerable<ComplexMessage> GetComplexMessages()
@@ -77,7 +77,7 @@ partial class ChannelSampleServerNexus
         while (true)
         {
             yield return ComplexMessage.Random();
-            if (++count >= 10000)
+            if (++count >= 1000)
                 yield break;
         }
     }

--- a/src/NexNetDemo/Samples/Channel/ChannelSampleNexuses.cs
+++ b/src/NexNetDemo/Samples/Channel/ChannelSampleNexuses.cs
@@ -12,6 +12,7 @@ interface IChannelSampleServerNexus
     ValueTask IntegerChannel(INexusDuplexUnmanagedChannel<int> channel);
     ValueTask StructChannel(INexusDuplexUnmanagedChannel<ChannelSampleStruct> channel);
     ValueTask ClassChannel(INexusDuplexChannel<ComplexMessage> channel);
+    ValueTask ClassChannelBatch(INexusDuplexChannel<ComplexMessage> channel);
 }
 
 
@@ -62,6 +63,22 @@ partial class ChannelSampleServerNexus
 
             if (count++ > 100)
                 return;
+        }
+    }
+
+    public async ValueTask ClassChannelBatch(INexusDuplexChannel<ComplexMessage> channel)
+    {
+        await channel.WriteAndComplete(GetComplexMessages(), 100);
+    }
+
+    private static IEnumerable<ComplexMessage> GetComplexMessages()
+    {
+        var count = 0;
+        while (true)
+        {
+            yield return ComplexMessage.Random();
+            if (count++ > 1000)
+                yield break;
         }
     }
 }


### PR DESCRIPTION
## Modifications
- Added the following extensions for common scenarios of Channel usage.
- Added NexusPipeReader.IsComplete property.
- Fixed issue with AdvanceTo not advancing the examined position.

## Usage Exmaple
```cs
public static async ValueTask WriteAndComplete<T>(
    this INexusDuplexChannel<T> channel,
    IEnumerable<T> enumerableData,
    int chunkSize = 10,
    CancellationToken cancellationToken = default)

public static async ValueTask WriteAndComplete<T>(
    this INexusChannelWriter<T> writer,
    IEnumerable<T> enumerableData,
    int chunkSize = 10,
    CancellationToken cancellationToken = default)

public static async ValueTask<List<T>> ReadUntilComplete<T>(
    this INexusDuplexChannel<T> channel,
    int estimatedSize = 0,
    CancellationToken cancellationToken = default)

public static async ValueTask<List<T>> ReadUntilComplete<T>(
    this INexusChannelReader<T> reader,
    int estimatedSize = 0,
    CancellationToken cancellationToken = default)
```