### PR TITLE
Null Proxy Return Warning Fixes

### DIFF
--- a/src/NexNet.Generator/NexusGenerator.Emitter.cs
+++ b/src/NexNet.Generator/NexusGenerator.Emitter.cs
@@ -378,7 +378,7 @@ partial class MethodMeta
 
         if (SerializedParameters > 0)
         {
-            sb.Append("                 var arguments = new global::System.ValueTuple<");
+            sb.Append("                 var __proxyInvocationArguments = new global::System.ValueTuple<");
             
             foreach (var p in Parameters)
             {
@@ -414,7 +414,7 @@ partial class MethodMeta
             sb.Append(this.DuplexPipeParameter == null ? "_ = " : "return ");
 
             sb.Append("__ProxyInvokeMethodCore(").Append(this.Id).Append(", ");
-            sb.Append(SerializedParameters > 0 ? "arguments, " : "null, ");
+            sb.Append(SerializedParameters > 0 ? "__proxyInvocationArguments, " : "null, ");
 
             // If we have a duplex pipe parameter, we need to pass the duplex pipe invocation flag.
             sb.Append("global::NexNet.Messages.InvocationFlags.").Append(this.DuplexPipeParameter == null ? "None" : "DuplexPipe").AppendLine(");");
@@ -428,7 +428,7 @@ partial class MethodMeta
             }
 
             sb.Append("(").Append(this.Id).Append(", "); // methodId
-            sb.Append(SerializedParameters > 0 ? "arguments, " : "null, "); // arguments
+            sb.Append(SerializedParameters > 0 ? "__proxyInvocationArguments, " : "null, "); // arguments
             sb.Append(CancellationTokenParameter != null ? CancellationTokenParameter.Name : "null").AppendLine(");");
         }
 

--- a/src/NexNet/Messages/InvocationResultMessage.cs
+++ b/src/NexNet/Messages/InvocationResultMessage.cs
@@ -40,20 +40,16 @@ internal partial class InvocationResultMessage : IMessageBase
         set => _result = value;
     }
 
-    public T? GetResult<T>()
+    public bool TryGetResult<T>(out T? result)
     {
         if (_result == null)
-            return default;
+        {
+            result = default;
+            return false;
+        }
 
-        return MemoryPackSerializer.Deserialize<T>(_result.Value);
-    }
-
-    public object? GetResult(Type? type)
-    {
-        if (_result == null || type == null)
-            return default;
-
-        return MemoryPackSerializer.Deserialize(type, _result.Value);
+        result = MemoryPackSerializer.Deserialize<T>(_result.Value);
+        return true;
     }
 
     public void Dispose()

--- a/src/NexNet/NexusServer.cs
+++ b/src/NexNet/NexusServer.cs
@@ -16,7 +16,7 @@ namespace NexNet;
 /// </summary>
 /// <typeparam name="TServerNexus">The nexus which will be running locally on the server.</typeparam>
 /// <typeparam name="TClientProxy">Proxy used to invoke methods on the remote nexus.</typeparam>
-public sealed class NexusServer<TServerNexus, TClientProxy> : INexusServer<TClientProxy>, INexusServer 
+public sealed class NexusServer<TServerNexus, TClientProxy> : INexusServer<TClientProxy> 
     where TServerNexus : ServerNexusBase<TClientProxy>, IInvocationMethodHash
     where TClientProxy : ProxyInvocationBase, IProxyInvoker, IInvocationMethodHash, new()
 {
@@ -259,7 +259,7 @@ public sealed class NexusServer<TServerNexus, TClientProxy> : INexusServer<TClie
 
                 // Create a composite ID of the current ticks along with the current ticks.
                 // This makes guessing IDs harder, but not impossible.
-                var baseSessionId = Interlocked.Increment(ref _sessionIdIncrementer);
+                var baseSessionId = _sessionIdIncrementer++;
 
                 // boxed, but only once per client
                 StartOnScheduler(
@@ -272,8 +272,7 @@ public sealed class NexusServer<TServerNexus, TClientProxy> : INexusServer<TClie
                         Configs = _config,
                         SessionManager = _sessionManager,
                         IsServer = true,
-                        // ReSharper disable once RedundantCast
-                        Id = (long)baseSessionId << 32 | (long)Environment.TickCount,
+                        Id = (long)baseSessionId << 32 | (long)Random.Shared.Next(),
                         Nexus = _nexusFactory.Invoke()
                     });
             }

--- a/src/NexNet/Pipes/NexusChannelExtensions.cs
+++ b/src/NexNet/Pipes/NexusChannelExtensions.cs
@@ -101,14 +101,14 @@ public static class NexusChannelExtensions
     /// <param name="cancellationToken">An optional CancellationToken to observe while waiting for the task to complete.</param>
     /// <returns>A ValueTask that represents the asynchronous read operation. The task result contains a List of type T with the data read from the channel.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static async ValueTask<List<T>> ReadUntilComplete<T, TTo>(
+    public static async ValueTask<List<TTo>> ReadUntilComplete<T, TTo>(
         this INexusDuplexChannel<T> channel,
         Converter<T, TTo> converter,
         int estimatedSize = 0,
         CancellationToken cancellationToken = default)
     { 
         var reader = await channel.GetReaderAsync().ConfigureAwait(false);
-        return await ReadUntilComplete<T>(reader, estimatedSize, cancellationToken).ConfigureAwait(false);
+        return await ReadUntilComplete<T, TTo>(reader, converter, estimatedSize, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>


### PR DESCRIPTION
- Fixed warnings related to __ProxyInvokeAndWaitForResultCore returning nullable values by default.
- Fixed converter issue with ReadUntilComplete.
- Fixed #23
- Replaced the environment tick count with random integer for session Id creation.