### PR TITLE
Pipe Notifications, Checks, & Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,12 +101,12 @@ MaxWarmupIterationCount=3  MinIterationCount=3  MinWarmupIterationCount=1
 ## Method Invocation Table
 Some methods are handled differently based upon the arguments passed and there are limitations placed upon the types of arguments which can be used together.  Most of these incompatibilities handled with Diagnostic Errors provided by the `NexNet.Generator`.  Below is a table which shows valid combinations of arguments and return values.
 
-|              | CancellationToken | INexusDuplexPipe | INexusChannel<T> | Args |
-|--------------|-------------------|------------------|------------------|------|
-| void         |                   |                  |                  | X    |
-| ValueTask    | X                 |                  |                  | X    |
-| ValueTask    |                   | X                | X                | X    |
-| ValueTask<T> | X                 |                  |                  | X    |
+|                    | CancellationToken | INexusDuplexPipe | INexusChannel<T> | Args |
+|--------------------|-------------------|------------------|------------------|------|
+| void               |                   |                  |                  | X    |
+| ValueTask          | X                 |                  |                  | X    |
+| ValueTask          |                   | X                | X                | X    |
+| ValueTask&lt;T&gt; | X                 |                  |                  | X    |
 
 Notes:
 - `CancellationToken`s can't be combined with `NexusDuplexPipe` nor `INexusChannel<T>` due to pipes/channels having built-in cancellation/completion notifications.

--- a/src/NexNet.IntegrationTests/Pipes/NexusChannelReaderWriterTests.cs
+++ b/src/NexNet.IntegrationTests/Pipes/NexusChannelReaderWriterTests.cs
@@ -83,7 +83,7 @@ internal class NexusChannelReaderWriterTests : NexusChannelReaderWriterTestBase
             await reader.Reader.CompleteAsync();
         });
         
-        var completeRead = await reader.ReadUntilComplete();
+        var completeRead = await reader.ReadUntilComplete().Timeout(1);
 
         Assert.AreEqual(0, completeRead.Count);
     }

--- a/src/NexNet/Pipes/INexusChannelReader.cs
+++ b/src/NexNet/Pipes/INexusChannelReader.cs
@@ -22,24 +22,12 @@ public interface INexusChannelReader<T>
     long BufferedLength { get; }
 
     /// <summary>
-    /// Asynchronously reads data from the duplex pipe.
-    /// </summary>
-    /// <param name="cancellationToken"></param>
-    /// <returns>
-    /// A task that represents the asynchronous read operation. The value of the TResult parameter contains an enumerable collection of type T.
-    /// If the read operation is completed or canceled, the returned task will contain an empty collection.
-    /// </returns>
-    ValueTask<IReadOnlyList<T>> ReadAsync(CancellationToken cancellationToken = default);
-
-    /// <summary>
     /// Asynchronously reads data from the duplex pipe and converts it using the provided converter function.
     /// </summary>
     /// <typeparam name="TTo">The type of the items that will be returned after conversion.</typeparam>
-    /// <param name="converter">A function that converts each item of type T to type TTo.</param>
+    /// <param name="list">The list to which the converted items will be added.</param>
+    /// <param name="converter">An optional converter function that converts each item of type T to type TTo.</param>
     /// <param name="cancellationToken">An optional token to cancel the read operation.</param>
-    /// <returns>
-    /// A task that represents the asynchronous read operation. The value of the TResult parameter contains an enumerable collection of type TTo.
-    /// If the read operation is completed or canceled, the returned task will contain an empty collection.
-    /// </returns>
-    ValueTask<IReadOnlyList<TTo>> ReadAsync<TTo>(Converter<T, TTo> converter, CancellationToken cancellationToken = default);
+    /// <returns>True if there is more data to be read from the channel, otherwise false when closed or completed.</returns>
+    ValueTask<bool> ReadAsync<TTo>(List<TTo> list, Converter<T, TTo>? converter, CancellationToken cancellationToken = default);
 }

--- a/src/NexNet/Pipes/INexusDuplexPipe.cs
+++ b/src/NexNet/Pipes/INexusDuplexPipe.cs
@@ -19,6 +19,11 @@ public interface INexusDuplexPipe : IDuplexPipe
     Task ReadyTask { get; }
 
     /// <summary>
+    /// Task which completes when the pipe has been completed on the invoking side.
+    /// </summary>
+    Task CompleteTask { get; }
+
+    /// <summary>
     /// Sets the pipe to the complete state and closes the other end of the connection.
     /// Do not use the pipe after calling this method.
     /// </summary>

--- a/src/NexNet/Pipes/NexusChannelExtensions.cs
+++ b/src/NexNet/Pipes/NexusChannelExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO.Pipelines;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -87,7 +88,7 @@ public static class NexusChannelExtensions
         int estimatedSize = 0,
         CancellationToken cancellationToken = default)
     {
-        return ReadUntilComplete<T, T>(channel, static (in T t) => t, estimatedSize, cancellationToken);
+        return ReadUntilComplete<T, T>(channel, null, estimatedSize, cancellationToken);
     }
 
     /// <summary>
@@ -96,14 +97,14 @@ public static class NexusChannelExtensions
     /// <typeparam name="T">The source type of the data that can be transmitted through the channel.</typeparam>
     /// <typeparam name="TTo">The type of the items that will be returned after conversion.</typeparam>
     /// <param name="channel">The duplex channel from which the data will be read.</param>
-    /// <param name="converter">A function that converts each item of type T to type TTo.</param>
+    /// <param name="converter">An optional function that converts each item of type T to type TTo.</param>
     /// <param name="estimatedSize">An optional parameter to set the initial capacity of the list that will store the read data.</param>
     /// <param name="cancellationToken">An optional CancellationToken to observe while waiting for the task to complete.</param>
     /// <returns>A ValueTask that represents the asynchronous read operation. The task result contains a List of type T with the data read from the channel.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static async ValueTask<List<TTo>> ReadUntilComplete<T, TTo>(
         this INexusDuplexChannel<T> channel,
-        Converter<T, TTo> converter,
+        Converter<T, TTo>? converter,
         int estimatedSize = 0,
         CancellationToken cancellationToken = default)
     { 
@@ -125,7 +126,7 @@ public static class NexusChannelExtensions
         int estimatedSize = 0,
         CancellationToken cancellationToken = default)
     {
-        return ReadUntilComplete<T, T>(reader, static (in T t) => t, estimatedSize, cancellationToken);
+        return ReadUntilComplete<T, T>(reader, null, estimatedSize, cancellationToken);
     }
 
     /// <summary>
@@ -134,18 +135,125 @@ public static class NexusChannelExtensions
     /// <typeparam name="T">The source type of the data that can be transmitted through the channel.</typeparam>
     /// <typeparam name="TTo">The type of the items that will be returned after conversion.</typeparam>
     /// <param name="reader">The channel reader from which the data will be read.</param>
-    /// <param name="converter">A function that converts each item of type T to type TTo.</param>
+    /// <param name="converter">An optional function that converts each item of type T to type TTo.</param>
     /// <param name="estimatedSize">An optional parameter to set the initial capacity of the list that will store the read data.</param>
     /// <param name="cancellationToken">An optional CancellationToken to observe while waiting for the task to complete.</param>
     /// <returns>A ValueTask that represents the asynchronous read operation. The task result contains a List of type T with the data read from the channel.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static async ValueTask<List<TTo>> ReadUntilComplete<T, TTo>(
         this INexusChannelReader<T> reader,
-        Converter<T, TTo> converter,
+        Converter<T, TTo>? converter,
         int estimatedSize = 0,
         CancellationToken cancellationToken = default)
     {
         var list = new List<TTo>(estimatedSize);
+
+        await ReadBatchUntilComplete<T, TTo, List<TTo>>(
+                reader,
+                converter,
+                static (readData, listRef) =>
+                {
+                    listRef.AddRange(readData);
+                }, list, cancellationToken)
+            .ConfigureAwait(false);
+
+        return list;
+    }
+
+    /// <summary>
+    /// Reads data in batches from the given channel reader until the reader is complete and performs an action on each batch.
+    /// </summary>
+    /// <typeparam name="T">The source type of the data that can be transmitted through the channel.</typeparam>
+    /// <param name="reader">The channel reader from which the data will be read.</param>
+    /// <param name="action">An action that will be executed for each batch of data read from the channel.</param>
+    /// <param name="cancellationToken">An optional CancellationToken to observe while waiting for the task to complete.</param>
+    /// <returns>A ValueTask that represents the asynchronous read operation. The task result contains a List of type T with the data read from the channel.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static ValueTask ReadBatchUntilComplete<T>(
+        this INexusChannelReader<T> reader,
+        Action<IReadOnlyList<T>> action,
+        CancellationToken cancellationToken = default)
+    {
+        return ReadBatchUntilComplete<T, T, Action<IReadOnlyList<T>>>(
+            reader, 
+            null,
+            static (list, action) => action(list),
+            action, 
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Reads data in batches from the given channel reader until the reader is complete, converts the data, and performs an action on each batch.
+    /// </summary>
+    /// <typeparam name="T">The type of the data that can be read from the channel.</typeparam>
+    /// <typeparam name="TTo">The type to which the data will be converted.</typeparam>
+    /// <param name="reader">The channel reader from which the data will be read.</param>
+    /// <param name="converter">An optional function that converts each item of type T to type TTo.</param>
+    /// <param name="action">An action that will be executed for each batch of data read from the channel.</param>
+    /// <param name="cancellationToken">An optional CancellationToken to observe while waiting for the task to complete.</param>
+    /// <returns>A ValueTask that represents the asynchronous read operation.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static ValueTask ReadBatchUntilComplete<T, TTo>(
+        this INexusChannelReader<T> reader,
+        Converter<T, TTo>? converter,
+        Action<IReadOnlyList<TTo>> action,
+        CancellationToken cancellationToken = default)
+    {
+        return ReadBatchUntilComplete(
+            reader,
+            converter,
+            static (list, action) => action(list),
+            action,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Reads data in batches from the given channel reader until the reader is complete and performs an action on each batch.
+    /// </summary>
+    /// <typeparam name="T">The source type of the data that can be transmitted through the channel.</typeparam>
+    /// <typeparam name="TContextObj">The type of the object that will be passed to the action.</typeparam>
+    /// <param name="reader">The channel reader from which the data will be read.</param>
+    /// <param name="action">An action that will be executed for each batch of data read from the channel.</param>
+    /// <param name="contextObject">An object that will be passed to the action.</param>
+    /// <param name="cancellationToken">An optional CancellationToken to observe while waiting for the task to complete.</param>
+    /// <returns>A ValueTask that represents the asynchronous read operation. The task result contains a List of type T with the data read from the channel.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static ValueTask ReadBatchUntilComplete<T, TContextObj>(
+        this INexusChannelReader<T> reader,
+        Action<IReadOnlyList<T>, TContextObj> action,
+        TContextObj contextObject,
+        CancellationToken cancellationToken = default)
+    {
+        return ReadBatchUntilComplete(
+            reader, 
+            null, 
+            action, 
+            contextObject, 
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Reads data in batches from the given channel reader until the reader is complete, converts the data, and performs an action on each batch.
+    /// </summary>
+    /// <typeparam name="T">The type of the data that can be read from the channel.</typeparam>
+    /// <typeparam name="TTo">The type to which the data will be converted.</typeparam>
+    /// <typeparam name="TContextObj">The type of the context object that will be passed to the action. Used to prevent the creation of a closure.</typeparam>
+    /// <param name="reader">The channel reader from which the data will be read.</param>
+    /// <param name="converter">A function that converts each item of type T to type TTo.</param>
+    /// <param name="action">An action that will be executed for each batch of data read from the channel.</param>
+    /// <param name="contextObject">An object that will be passed to the action. Used to prevent the creation of a closure.</param>
+    /// <param name="cancellationToken">An optional CancellationToken to observe while waiting for the task to complete.</param>
+    /// <returns>A ValueTask that represents the asynchronous read operation.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static async ValueTask ReadBatchUntilComplete<T, TTo, TContextObj>(
+        this INexusChannelReader<T> reader,
+        Converter<T, TTo>? converter,
+        Action<IReadOnlyList<TTo>, TContextObj> action,
+        TContextObj contextObject,
+        CancellationToken cancellationToken = default)
+    {
+        var list = ListPool<TTo>.Rent();
+
         while (true)
         {
             var previousBufferLength = reader.BufferedLength;
@@ -153,24 +261,21 @@ public static class NexusChannelExtensions
             if (reader.IsComplete && previousBufferLength == 0)
                 break;
 
-            var readResult = await reader.ReadAsync(converter, cancellationToken)
+            list.Clear();
+            var readResult = await reader.ReadAsync(list, converter, cancellationToken)
                 .ConfigureAwait(false);
-            var resultCount = readResult.Count;
-            if (reader.IsComplete
-                && resultCount == 0
-                && previousBufferLength == reader.BufferedLength)
-                return list;
 
-            if (resultCount > 0)
+            if (readResult == false && previousBufferLength == reader.BufferedLength)
+                return;
+
+            if (list.Count > 0)
             {
-                list.AddRange(readResult);
-
-                // Return the list to the pool.
-                ListPool<TTo>.Return(Unsafe.As<List<TTo>>(readResult));
+                action(list, contextObject);
             }
         }
 
-        return list;
+        // Return the list to the pool.
+        ListPool<TTo>.Return(Unsafe.As<List<TTo>>(list));
     }
 
 }

--- a/src/NexNet/Pipes/NexusChannelReaderExtensions.cs
+++ b/src/NexNet/Pipes/NexusChannelReaderExtensions.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NexNet.Pipes;
+
+/// <summary>
+/// Extension methods for the <see cref="INexusChannelReader{T}"/> interface.
+/// </summary>
+public static class NexusChannelReaderExtensions
+{
+    /// <summary>
+    /// Asynchronously reads data from the duplex pipe.
+    /// </summary>
+    /// <param name="reader">The Nexus channel reader from which to read the items.</param>
+    /// <param name="cancellationToken">An optional token to cancel the read operation.</param>
+    /// <returns>
+    /// A task that represents the asynchronous read operation. The value of the TResult parameter contains an enumerable collection of type T.
+    /// If the read operation is completed or canceled, the returned task will contain an empty collection.
+    /// </returns>
+    public static async ValueTask<List<T>> ReadAsync<T>(
+        this INexusChannelReader<T> reader,
+        CancellationToken cancellationToken = default)
+    {
+        var list = new List<T>();
+        await reader.ReadAsync(list, null, cancellationToken).ConfigureAwait(false);
+        return list;
+    }
+}

--- a/src/NexNetDemo/Program.cs
+++ b/src/NexNetDemo/Program.cs
@@ -11,14 +11,14 @@ internal class Program
     static async Task Main(string[] args)
     {
         //await new DuplexPipeSimpleSample().UploadSample();
-        await new DuplexPipeStreamingSample(SampleBase.TransportMode.Uds).UploadStreamingSample();
+        //await new DuplexPipeStreamingSample(SampleBase.TransportMode.Uds).UploadStreamingSample();
         //await new DuplexPipeStreamingSample(SampleBase.TransportMode.Quic).DuplexStreamingSample();
         //await new ChannelSample(SampleBase.TransportMode.Uds).UnmanagedChannelSample();
         //await new ChannelSample(SampleBase.TransportMode.Uds).ChannelStructSample();
         //await new ChannelSample(SampleBase.TransportMode.Uds).ClassSample();
         //await new ChannelSample(SampleBase.TransportMode.Uds).ClassChannelBatchSample();
         //await new ChannelSample(SampleBase.TransportMode.Uds).UnmanagedChannelSample();
-        //await new ChannelSample(SampleBase.TransportMode.Uds).ChannelStructConvertSample();
+        await new ChannelSample(SampleBase.TransportMode.Uds).ChannelStructConvertSample();
         //await new DuplexPipeStreamingSample().DuplexStreamingSample();
         //await new InvocationSample().UpdateInfo();
 

--- a/src/NexNetDemo/Samples/Channel/ChannelSample.cs
+++ b/src/NexNetDemo/Samples/Channel/ChannelSample.cs
@@ -45,13 +45,26 @@ public class ChannelSample : SampleBase
 
         var reader = await pipe.GetReaderAsync();
 
-        while (!reader.IsComplete)
+        await reader.ReadBatchUntilComplete(batch =>
         {
-            foreach (var channelSampleStruct in await reader.ReadAsync())
+            foreach (var channelSampleStruct in batch)
             {
                 Console.WriteLine(channelSampleStruct);
             }
+        });
+
+        // ---OR---
+        /*
+        var list = new List<ChannelSampleStruct>();
+        while (await reader.ReadAsync(list, null))
+        {
+            foreach (var channelSampleStruct in list)
+            {
+                Console.WriteLine(channelSampleStruct);
+            }
+            list.Clear();
         }
+        */
     }
 
     private class ChannelSampleStruct2
@@ -81,13 +94,28 @@ public class ChannelSample : SampleBase
             Id = s.Id,
             Counts = s.Counts
         };
-        while (!reader.IsComplete)
+
+        await reader.ReadBatchUntilComplete(batch =>
         {
-            foreach (var channelSampleStruct in await reader.ReadAsync(Convert))
+            foreach (var channelSampleStruct in batch)
             {
                 Console.WriteLine(channelSampleStruct);
             }
+        });
+
+        // ---OR---
+
+        /*
+        var list = new List<ChannelSampleStruct2>();
+        while (await reader.ReadAsync(list, Convert))
+        {
+            foreach (var channelSampleStruct in list)
+            {
+                Console.WriteLine(channelSampleStruct);
+            }
+            list.Clear();
         }
+        */
     }
 
     public async Task ClassSample()
@@ -100,13 +128,27 @@ public class ChannelSample : SampleBase
         
         var reader = await pipe.GetReaderAsync();
 
-        while (!reader.IsComplete)
+        await reader.ReadBatchUntilComplete(batch =>
         {
-            foreach (var channelSampleStruct in await reader.ReadAsync())
+            foreach (var channelSampleStruct in batch)
             {
                 Console.WriteLine(channelSampleStruct);
             }
+        });
+
+        // ---OR---
+
+        /*
+        var list = new List<ComplexMessage>();
+        while (await reader.ReadAsync(list, null))
+        {
+            foreach (var channelSampleStruct in list)
+            {
+                Console.WriteLine(channelSampleStruct);
+            }
+            list.Clear();
         }
+        */
     }
 
     public async Task ClassChannelBatchSample()
@@ -118,6 +160,11 @@ public class ChannelSample : SampleBase
         await client.Proxy.ClassChannelBatch(pipe);
 
         var result = await pipe.ReadUntilComplete(1000);
+
+        foreach (var complexMessage in result)
+        {
+            Console.WriteLine(complexMessage);
+        }
     }
 
     private async Task<(NexusServer<ChannelSampleServerNexus, ChannelSampleServerNexus.ClientProxy> server, NexusClient<ChannelSampleClientNexus, ChannelSampleClientNexus.ServerProxy> client)> Setup()


### PR DESCRIPTION
### Changes
- Added `NexusDuplexPipe.CompleteTask` property to notify when the pipe is complete.
- Added additional checks to prevent passing a used or wrong pipe to a proxy invocation.  This could happen by creating a pipe in the wrong nexus and passing it to the opposite nexus.
- Added tests.
- Added `ReadBatchUntilComplete` and overloads to allow for batch reading.
- Refactored to remove needless list creations and allowed passing of a list to the readers.
- Extracted some methods into extension methods instead of hard class methods.
- `ReadAsync` now returns a bool to relay whether or not the reading is complete.