### PR TITLE
Proxy Invocations Except Current Session

### DIFF
--- a/src/NexNet.Generator/NexusGenerator.Emitter.cs
+++ b/src/NexNet.Generator/NexusGenerator.Emitter.cs
@@ -297,7 +297,8 @@ partial class MethodMeta
     /// Emits the invocation of the method on the nexus.
     /// </summary>
     /// <param name="sb"></param>
-    public void EmitNexusMethodInvocation(StringBuilder sb, bool writeParamNames)
+    /// <param name="forLog">Change the output to write the output params. Used for logging.</param>
+    public void EmitNexusMethodInvocation(StringBuilder sb, bool forLog)
     {
         sb.Append(this.Name).Append("(");
 
@@ -309,7 +310,7 @@ partial class MethodMeta
             // otherwise we need to pass the serialized value.
             if (methodParameterMeta.IsDuplexPipe)
             {
-                if (writeParamNames)
+                if (forLog)
                 {
                     sb.Append(methodParameterMeta.Name)
                         .Append(" = {arguments.Item")
@@ -325,7 +326,7 @@ partial class MethodMeta
             }
             else if (methodParameterMeta.IsDuplexUnmanagedChannel)
             {
-                if (writeParamNames)
+                if (forLog)
                 {
                     sb.Append(methodParameterMeta.Name)
                         .Append(" = {arguments.Item")
@@ -343,7 +344,7 @@ partial class MethodMeta
             }
             else if (methodParameterMeta.IsDuplexChannel)
             {
-                if (writeParamNames)
+                if (forLog)
                 {
                     sb.Append(methodParameterMeta.Name)
                         .Append(" = {arguments.Item")
@@ -361,7 +362,7 @@ partial class MethodMeta
             }
             else if (methodParameterMeta.SerializedValue != null)
             {
-                if (writeParamNames)
+                if (forLog)
                 {
                     sb.Append(methodParameterMeta.Name)
                         .Append(" = {arguments.Item")
@@ -379,7 +380,7 @@ partial class MethodMeta
 
         if (CancellationTokenParameter != null)
         {
-            if (writeParamNames)
+            if (forLog)
             {
                 sb.Append(CancellationTokenParameter.Name).Append(" = ct");
             }
@@ -396,7 +397,7 @@ partial class MethodMeta
 
         sb.Append(");");
 
-        if (!writeParamNames)
+        if (!forLog)
             sb.AppendLine();
     }
 

--- a/src/NexNet.props
+++ b/src/NexNet.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.7.0</Version>
+    <Version>0.8.0</Version>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <TargetFramework>net8.0</TargetFramework>

--- a/src/NexNet.props
+++ b/src/NexNet.props
@@ -8,7 +8,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <Company>Dtronix</Company>
     <Product>NexNet</Product>
-    <Copyright>Copyright © Dtronix 2023</Copyright>
+    <Copyright>Copyright © Dtronix 2024</Copyright>
     <Authors>DJGosnell</Authors>
     <PackageProjectUrl>https://github.com/Dtronix/NexNet</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Dtronix/NexNet</RepositoryUrl>

--- a/src/NexNet/Internals/Pipelines/ConnectionAbortedException.cs
+++ b/src/NexNet/Internals/Pipelines/ConnectionAbortedException.cs
@@ -24,6 +24,4 @@ internal sealed class ConnectionAbortedException : OperationCanceledException
     /// Create a new instance of ConnectionAbortedException
     /// </summary>
     public ConnectionAbortedException(string message, Exception inner) : base(message, inner) { }
-
-    private ConnectionAbortedException(SerializationInfo info, StreamingContext context) : base(info, context) { }
 }

--- a/src/NexNet/Internals/Pipelines/ConnectionResetException.cs
+++ b/src/NexNet/Internals/Pipelines/ConnectionResetException.cs
@@ -24,6 +24,4 @@ internal sealed class ConnectionResetException : IOException
     /// Create a new ConnectionResetException instance
     /// </summary>
     public ConnectionResetException(string message, Exception inner) : base(message, inner) { }
-
-    private ConnectionResetException(SerializationInfo info, StreamingContext context) : base(info, context) { }
 }

--- a/src/NexNet/Invocation/IProxyBase.cs
+++ b/src/NexNet/Invocation/IProxyBase.cs
@@ -36,11 +36,27 @@ public interface IProxyBase<out TProxy>
     TProxy Group(string groupName);
 
     /// <summary>
+    /// Proxy for all clients part of the specified group.
+    /// Will not send the invocation to the current calling session.
+    /// </summary>
+    /// <param name="groupName">Group name to get the proxy for.</param>
+    /// <returns>Proxy</returns>
+    TProxy GroupExceptCaller(string groupName);
+
+    /// <summary>
     /// Proxy for all clients part of the specified groups.
     /// </summary>
     /// <param name="groupName">Group names to get the proxies for.</param>
     /// <returns>Proxy</returns>
     TProxy Groups(string[] groupName);
+
+    /// <summary>
+    /// Proxy for all clients part of the specified groups.
+    /// Will not send the invocation to the current calling session.
+    /// </summary>
+    /// <param name="groupName">Group names to get the proxies for.</param>
+    /// <returns>Proxy</returns>
+    TProxy GroupsExceptCaller(string[] groupName);
 
     /// <summary>
     /// Gets all the connected client ids.

--- a/src/NexNet/Invocation/ProxyInvocationBase.cs
+++ b/src/NexNet/Invocation/ProxyInvocationBase.cs
@@ -268,7 +268,7 @@ public abstract class ProxyInvocationBase : IProxyInvoker
     }
 
     /// <inheritdoc />
-    async ValueTask IProxyInvoker.ProxyInvokeAndWaitForResultCore(ushort methodId, ITuple? arguments, CancellationToken? cancellationToken = null)
+    async ValueTask IProxyInvoker.ProxyInvokeAndWaitForResultCore(ushort methodId, ITuple? arguments, CancellationToken? cancellationToken)
     {
         var state = await InvokeWaitForResultCore(methodId, arguments, cancellationToken).ConfigureAwait(false);
 
@@ -292,7 +292,7 @@ public abstract class ProxyInvocationBase : IProxyInvoker
     }
 
     /// <inheritdoc />
-    async ValueTask<TReturn> IProxyInvoker.ProxyInvokeAndWaitForResultCore<TReturn>(ushort methodId, ITuple? arguments, CancellationToken? cancellationToken = null)
+    async ValueTask<TReturn> IProxyInvoker.ProxyInvokeAndWaitForResultCore<TReturn>(ushort methodId, ITuple? arguments, CancellationToken? cancellationToken)
     {
         var state = await InvokeWaitForResultCore(methodId, arguments, cancellationToken).ConfigureAwait(false);
 

--- a/src/NexNet/Invocation/ProxyInvocationMode.cs
+++ b/src/NexNet/Invocation/ProxyInvocationMode.cs
@@ -10,4 +10,5 @@ internal enum ProxyInvocationMode
     Clients,
     //Group,
     Groups,
+    GroupsExceptCaller,
 }

--- a/src/NexNet/Invocation/ServerNexusContext.cs
+++ b/src/NexNet/Invocation/ServerNexusContext.cs
@@ -95,7 +95,34 @@ public class ServerNexusContext<TClientProxy> : IDisposable
             return proxy;
         }
 
+        public TClientProxy GroupExceptCaller(string groupName)
+        {
+            var proxy = _cacheManager.ProxyCache.Rent(
+                null,
+                _sessionManager,
+                _cacheManager,
+                ProxyInvocationMode.Groups,
+                new[] { groupName });
+            _instancedProxies.Push(proxy);
+
+            return proxy;
+        }
+
+
         public TClientProxy Groups(string[] groupName)
+        {
+            var proxy = _cacheManager.ProxyCache.Rent(
+                null,
+                _sessionManager,
+                _cacheManager,
+                ProxyInvocationMode.Groups,
+                groupName);
+            _instancedProxies.Push(proxy);
+
+            return proxy;
+        }
+
+        public TClientProxy GroupsExceptCaller(string[] groupName)
         {
             var proxy = _cacheManager.ProxyCache.Rent(
                 null,

--- a/src/NexNet/Invocation/ServerSessionContext.cs
+++ b/src/NexNet/Invocation/ServerSessionContext.cs
@@ -119,12 +119,12 @@ public sealed class ServerSessionContext<TClientProxy> : SessionContext<TClientP
 
         public TClientProxy Group(string groupName)
         {
-            return Groups(new []{ groupName });
+            return Groups(new[] { groupName });
         }
 
         public TClientProxy GroupExceptCaller(string groupName)
         {
-            return Groups(new[] { groupName });
+            return GroupsExceptCaller(new[] { groupName });
         }
 
         public TClientProxy Groups(string[] groupName)
@@ -142,7 +142,15 @@ public sealed class ServerSessionContext<TClientProxy> : SessionContext<TClientP
 
         public TClientProxy GroupsExceptCaller(string[] groupName)
         {
-            return Groups(groupName);
+            var proxy = _cacheManager.ProxyCache.Rent(
+                _context.Session,
+                _context.SessionManager,
+                _context.Session.CacheManager,
+                ProxyInvocationMode.GroupsExceptCaller,
+                groupName);
+            _instancedProxies.Push(proxy);
+
+            return proxy;
         }
 
         public IEnumerable<long> GetIds()

--- a/src/NexNet/Invocation/ServerSessionContext.cs
+++ b/src/NexNet/Invocation/ServerSessionContext.cs
@@ -119,28 +119,12 @@ public sealed class ServerSessionContext<TClientProxy> : SessionContext<TClientP
 
         public TClientProxy Group(string groupName)
         {
-            var proxy = _cacheManager.ProxyCache.Rent(
-                _context.Session,
-                _context.SessionManager,
-                _context.Session.CacheManager,
-                ProxyInvocationMode.Groups,
-                new[] { groupName });
-            _instancedProxies.Push(proxy);
-
-            return proxy;
+            return Groups(new []{ groupName });
         }
 
         public TClientProxy GroupExceptCaller(string groupName)
         {
-            var proxy = _cacheManager.ProxyCache.Rent(
-                _context.Session,
-                _context.SessionManager,
-                _context.Session.CacheManager,
-                ProxyInvocationMode.GroupsExceptCaller,
-                new[] { groupName });
-            _instancedProxies.Push(proxy);
-
-            return proxy;
+            return Groups(new[] { groupName });
         }
 
         public TClientProxy Groups(string[] groupName)
@@ -158,15 +142,7 @@ public sealed class ServerSessionContext<TClientProxy> : SessionContext<TClientP
 
         public TClientProxy GroupsExceptCaller(string[] groupName)
         {
-            var proxy = _cacheManager.ProxyCache.Rent(
-                _context.Session,
-                _context.SessionManager,
-                _context.Session.CacheManager,
-                ProxyInvocationMode.GroupsExceptCaller,
-                groupName);
-            _instancedProxies.Push(proxy);
-
-            return proxy;
+            return Groups(groupName);
         }
 
         public IEnumerable<long> GetIds()

--- a/src/NexNet/Invocation/ServerSessionContext.cs
+++ b/src/NexNet/Invocation/ServerSessionContext.cs
@@ -130,6 +130,19 @@ public sealed class ServerSessionContext<TClientProxy> : SessionContext<TClientP
             return proxy;
         }
 
+        public TClientProxy GroupExceptCaller(string groupName)
+        {
+            var proxy = _cacheManager.ProxyCache.Rent(
+                _context.Session,
+                _context.SessionManager,
+                _context.Session.CacheManager,
+                ProxyInvocationMode.GroupsExceptCaller,
+                new[] { groupName });
+            _instancedProxies.Push(proxy);
+
+            return proxy;
+        }
+
         public TClientProxy Groups(string[] groupName)
         {
             var proxy = _cacheManager.ProxyCache.Rent(
@@ -137,6 +150,19 @@ public sealed class ServerSessionContext<TClientProxy> : SessionContext<TClientP
                 _context.SessionManager,
                 _context.Session.CacheManager,
                 ProxyInvocationMode.Groups,
+                groupName);
+            _instancedProxies.Push(proxy);
+
+            return proxy;
+        }
+
+        public TClientProxy GroupsExceptCaller(string[] groupName)
+        {
+            var proxy = _cacheManager.ProxyCache.Rent(
+                _context.Session,
+                _context.SessionManager,
+                _context.Session.CacheManager,
+                ProxyInvocationMode.GroupsExceptCaller,
                 groupName);
             _instancedProxies.Push(proxy);
 


### PR DESCRIPTION
- Extended proxy methods to include new for `GroupsExceptCaller` and `GroupExceptCaller` methods.  These methods allow for invoking on all the clients in the groups except the current calling session.
- Added tests.
- These new methods when called on the `ServerNexusContext` are ignored and the groups are invoked as there is not a "current session" when invoking directly on the nexus.
- Simplified invocation on `ServerSessionContext`.