### PR TITLE
Add method-level authorization via [NexusAuthorize<TPermission>]

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -22,7 +22,7 @@ jobs:
         submodules: 'recursive'
 
     - name: Install msquic
-      run: sudo apt install libmsquic=2.4.8
+      run: sudo apt-get update && sudo apt-get install -y libmsquic
 
     - name: Install .NET
       uses: actions/setup-dotnet@v4

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ NexNet is a .NET real-time asynchronous networking library, providing developers
 - High performance Socket and Pipeline usage.
 - Multiple transports and easy extensibility.
 - Connection rate limiting and DoS protection.
+- Declarative method and collection authorization with `[NexusAuthorize<TPermission>]`.
 - Strong Typed Hubs & Clients.
 - Server <-> Client communication
   - Synchronized collections (INexusList)
@@ -580,6 +581,138 @@ var clientConfig = new TcpClientConfig
     Authenticate = () => Encoding.UTF8.GetBytes("my-auth-token")
 };
 ```
+
+### Method Authorization
+
+NexNet provides declarative, source-generator-driven authorization for server nexus methods and synchronized collections. Authorization is enforced server-side before argument deserialization, preventing wasted work for unauthorized calls.
+
+#### Setup
+
+1. Define a permission enum (must use the default `int` backing type):
+
+```csharp
+public enum Permission { Read, Write, Admin }
+```
+
+2. Decorate server nexus methods with `[NexusAuthorize<TPermission>]`:
+
+```csharp
+[Nexus<IServerNexus, IClientNexus>(NexusType = NexusType.Server)]
+public partial class ServerNexus
+{
+    [NexusAuthorize<Permission>(Permission.Admin)]
+    public ValueTask AdminOnly() { ... }
+
+    [NexusAuthorize<Permission>(Permission.Read, Permission.Write)]
+    public ValueTask MultiPermission() { ... }
+
+    [NexusAuthorize<Permission>()]  // Marker-only: requires auth, no specific permission
+    public ValueTask AnyAuthenticated() { ... }
+
+    public ValueTask PublicMethod() { ... }  // No auth check
+}
+```
+
+3. Collections can also be authorized on the interface:
+
+```csharp
+public partial interface IServerNexus
+{
+    [NexusCollection(NexusCollectionMode.ServerToClient)]
+    [NexusAuthorize<Permission>(Permission.Admin)]
+    INexusList<string> SecureItems { get; }
+}
+```
+
+4. Override `OnAuthorize` to implement custom authorization logic:
+
+```csharp
+protected override ValueTask<AuthorizeResult> OnAuthorize(
+    ServerSessionContext<ClientProxy> context,
+    int methodId,
+    string methodName,
+    ReadOnlyMemory<int> requiredPermissions)
+{
+    var identity = context.Identity;
+    // Check permissions against your user/role system
+    // requiredPermissions contains the int-cast enum values from the attribute
+
+    return new ValueTask<AuthorizeResult>(
+        HasPermissions(identity, requiredPermissions)
+            ? AuthorizeResult.Allowed
+            : AuthorizeResult.Unauthorized);
+}
+```
+
+5. Handle unauthorized responses on the client:
+
+```csharp
+try
+{
+    await client.Proxy.AdminOnly();
+}
+catch (ProxyUnauthorizedException)
+{
+    // Server denied the invocation
+}
+```
+
+#### Authorization Results
+
+| Result | Behavior |
+|--------|----------|
+| `Allowed` | Method invocation proceeds normally |
+| `Unauthorized` | Returns error to caller without invoking the method. Collections silently drop the request |
+| `Disconnect` | Immediately disconnects the session. Use for collections or severe violations |
+
+If `OnAuthorize` throws an exception, the session is disconnected as a fail-safe to prevent accidental authorization bypass.
+
+#### Authorization Caching
+
+Authorization results can be cached per-session with configurable TTL to avoid calling `OnAuthorize` on every invocation. Caching is disabled by default.
+
+**Server-wide default:**
+```csharp
+var serverConfig = new TcpServerConfig
+{
+    EndPoint = endpoint,
+    AuthorizationCacheDuration = TimeSpan.FromSeconds(30)  // null = disabled (default)
+};
+```
+
+**Per-method override via attribute:**
+```csharp
+[NexusAuthorize<Permission>(Permission.Read, CacheDurationSeconds = 60)]   // 60s override
+[NexusAuthorize<Permission>(Permission.Admin, CacheDurationSeconds = 0)]   // Never cache
+[NexusAuthorize<Permission>(Permission.Write)]                              // Use server default
+```
+
+| Method Attribute | Server Config | Effective Cache |
+|------------------|---------------|-----------------|
+| Not set (`-1`) | `null` | No caching |
+| Not set (`-1`) | `30s` | 30s |
+| `0` | `30s` | No caching (explicit disable) |
+| `60` | `30s` | 60s (method wins) |
+| `10` | `null` | 10s (method wins) |
+
+Only `Allowed` and `Unauthorized` results are cached. `Disconnect` and exception paths are never cached. The cache is per-session and automatically cleared on reconnection.
+
+**Explicit invalidation** (inside nexus methods):
+```csharp
+InvalidateAuthorizationCache();           // Clear all cached results for this session
+InvalidateAuthorizationCache(methodId);   // Clear a specific method's cached result
+```
+
+#### Compile-Time Diagnostics
+
+The source generator enforces correct usage with compile-time errors:
+
+| ID | Description |
+|----|-------------|
+| NEXNET024 | `[NexusAuthorize]` used on a client nexus (server-only feature) |
+| NEXNET025 | `[NexusAuthorize]` used but `OnAuthorize` is not overridden |
+| NEXNET026 | Mixed permission enum types across `[NexusAuthorize]` attributes in the same nexus |
+| NEXNET027 | Permission enum is not backed by `int` (the default underlying type) |
 
 ### Connection Rate Limiting
 

--- a/llm-dev.md
+++ b/llm-dev.md
@@ -35,12 +35,14 @@ Single test: `dotnet test ... --filter "FullyQualifiedName~TestName"`
 - `NexusAttribute.cs` - `[Nexus<TNexus,TProxy>]` marks classes for generation; NexusType=Server/Client
 - `NexusMethodAttribute.cs` - Optional `[NexusMethod(id)]` for manual method ID assignment
 - `NexusVersionAttribute.cs` - `[NexusVersion]` enables interface versioning with hash validation
+- `NexusAuthorizeAttribute.cs` - `[NexusAuthorize<TPermission>(...)]` marks methods/collections for authorization; `CacheDurationSeconds` property (-1=server config, 0=never, >0=override)
+- `AuthorizeResult.cs` - Enum: Allowed, Unauthorized, Disconnect
 
 ### 1.3 Invocation Layer (src/NexNet/Invocation/)
 
 **Base Classes:**
 - `NexusBase.cs` - Common base; implements IMethodInvoker; manages CTS registry, pipe registration, pooling
-- `ServerNexusBase.cs` - Server base; OnAuthenticate, OnNexusInitialize virtuals
+- `ServerNexusBase.cs` - Server base; OnAuthenticate, OnNexusInitialize, OnAuthorize virtuals; CheckAuthorization with ConcurrentDictionary cache; InvalidateAuthorizationCache() overloads
 - `ClientNexusBase.cs` - Client base; OnReconnecting virtual
 
 **Contexts:**
@@ -50,7 +52,8 @@ Single test: `dotnet test ... --filter "FullyQualifiedName~TestName"`
 - `LocalSessionContext.cs` - Local session registry and key-value store
 
 **Proxy Infrastructure:**
-- `ProxyInvocationBase.cs` - Base for generated proxies; Configure() sets session/mode; supports All/Client/Group modes
+- `ProxyInvocationBase.cs` - Base for generated proxies; Configure() sets session/mode; supports All/Client/Group modes; handles Unauthorized state
+- `ProxyUnauthorizedException.cs` - Thrown client-side when server denies method invocation
 - `IProxyBase.cs` - Interface for proxy client selection (All, Client(id), Group(name), etc.)
 
 **Routing & Registry:**
@@ -64,12 +67,12 @@ Single test: `dotnet test ... --filter "FullyQualifiedName~TestName"`
 ### 1.4 Messages (src/NexNet/Messages/)
 
 **Protocol:**
-- `MessageType.cs` - Enum: Ping, Disconnect variants (20-33), DuplexPipeWrite (50), Greetings (100-105), Invocation (110-112)
+- `MessageType.cs` - Enum: Ping, Disconnect variants (20-34 incl. DisconnectUnauthorized), DuplexPipeWrite (50), Greetings (100-105), Invocation (110-112)
 - `IInvocationMessage.cs` - InvocationId, MethodId, Flags, Arguments; MaxArgumentSize=65,521 bytes
 - `ClientGreetingMessage.cs` - Client handshake: protocol version, nexus hash, auth token
 - `ServerGreetingMessage.cs` - Server response: session ID, server nexus hash
 - `InvocationMessage.cs` - Remote method invocation payload
-- `InvocationResultMessage.cs` - Return value or exception from invocation
+- `InvocationResultMessage.cs` - Return value, exception, or Unauthorized from invocation; StateType: Unset, CompletedResult, Exception, Unauthorized
 - `InvocationCancellationMessage.cs` - Cancel ongoing invocation
 
 ### 1.5 Session Management (src/NexNet/Internals/)
@@ -97,7 +100,7 @@ Single test: `dotnet test ... --filter "FullyQualifiedName~TestName"`
 **Configuration:**
 - `ConfigBase.cs` - Base: Timeout, PingInterval, Logger, PipeOptions
 - `ClientConfig.cs` - ConnectionTimeout, ReconnectionPolicy, Authenticate func
-- `ServerConfig.cs` - AcceptorBacklog, Authenticate bool, RateLimiting config
+- `ServerConfig.cs` - AcceptorBacklog, Authenticate bool, RateLimiting config, AuthorizationCacheDuration (nullable TimeSpan)
 
 **Socket Pipeline (src/NexNet/Internals/Pipelines/):**
 - `SocketConnection.cs` - Low-level socket-to-pipe adapter with read/write loops
@@ -171,9 +174,9 @@ Single test: `dotnet test ... --filter "FullyQualifiedName~TestName"`
 
 **Three Phases:**
 
-1. **Extraction:** `Extraction/NexusDataExtractor.cs` parses [Nexus<,>]; extracts namespace, type, modifiers, generics, interfaces, methods, collections.
+1. **Extraction:** `Extraction/NexusDataExtractor.cs` parses [Nexus<,>]; extracts namespace, type, modifiers, generics, interfaces, methods, collections, authorization data (permissions, enum type, cache duration).
 
-2. **Validation:** `Validation/NexusValidator.cs` validates class partial/not nested/not generic/not abstract; method signatures; collection modes; version hashes.
+2. **Validation:** `Validation/NexusValidator.cs` validates class partial/not nested/not generic/not abstract; method signatures; collection modes; version hashes; authorization (client nexus check, OnAuthorize override, mixed enum types, enum underlying type).
 
 3. **Emission (Emission/):**
    - `NexusEmitter.cs` - Generates partial class: CreateServer/CreateClient factories, collection properties
@@ -188,12 +191,13 @@ Single test: `dotnet test ... --filter "FullyQualifiedName~TestName"`
 - `InvocationInterfaceData.cs` - Methods, collections, version
 - `MethodData.cs` - Name, return type, parameters, method ID
 - `MethodParameterData.cs` - Name, type, serializable flag
-- `CollectionData.cs` - Name, type, mode, element type
+- `CollectionData.cs` - Name, type, mode, element type, AuthorizeData?
+- `AuthorizeData.cs` - Permissions (ImmutableArray<int>), PermissionEnumFQN, IsUnderlyingTypeCompatible, CacheDurationSeconds
 
 ### 2.3 Utilities
 
 - `TypeHasher.cs` - xxHash32-based interface signature hashing for versioning
-- `DiagnosticDescriptors.cs` - Error/warning/info definitions
+- `DiagnosticDescriptors.cs` - Error/warning/info definitions; NEXNET001-027 (024-027 are authorization: client nexus, missing OnAuthorize, mixed enums, non-int enum)
 - `SymbolUtilities.cs` - Symbol inspection helpers
 
 ---
@@ -236,6 +240,7 @@ Single test: `dotnet test ... --filter "FullyQualifiedName~TestName"`
 - `NexusServerFactory.cs` - Generic server wrapper tracking created nexuses in ConcurrentQueue
 - `TestInterfaces/BasicTestsInterfaces.cs` - IClientNexus, IServerNexus interfaces; ClientNexus, ServerNexus implementations with event callbacks
 - `TestInterfaces/VersionedTestsInterfaces.cs` - Version-specific test interfaces
+- `TestInterfaces/AuthorizationTestInterfaces.cs` - Authorization test nexuses with delegate handlers and cache invalidation helpers
 - `Utilities.cs` - Dequeue<T>(), GetBytes<T>(), GetValue<T>(), InvokeAndNotifyAwait()
 - `TaskExtensions.cs` - Timeout() overloads, AssertTimeout()
 - `Collections/CollectionHelpers.cs` - WaitForEvent() extension, WaitForActionHandler
@@ -260,6 +265,7 @@ Single test: `dotnet test ... --filter "FullyQualifiedName~TestName"`
 - `NexusServerTests_NexusInvocations.cs` - Nexus-to-nexus
 - `NexusServerTests_NexusGroupInvocations.cs` - Group invocations
 - `NexusServerTests_Versioned.cs` - Versioning
+- `NexusServerTests_Authorization.cs` - Authorization: allow/deny/disconnect, collections, caching (TTL, expiry, invalidation, concurrent access), multi-permission
 
 **Collections (Collections/, 24 files):**
 - `NexusCollectionAckTests.cs` - Acknowledgments
@@ -327,6 +333,7 @@ await client.ConnectAsync().Timeout(1);
 - `GeneratorCollectionTests.cs` - Collection property generation
 - `TypeHasherTests.cs` - Type hashing for method IDs
 - `VersioningTests.cs` - Version string parsing, [NexusVersion] + [NexusMethod(id)] validation
+- `GeneratorAuthorizationTests.cs` - Authorization attribute validation: client nexus error, missing OnAuthorize, mixed enums, non-int enum, cache duration, collection auth
 
 **Test Pattern:** Pass C# source string to RunGenerator(), check Diagnostic[] for expected IDs (MustBePartial, etc.)
 

--- a/llm-usage.md
+++ b/llm-usage.md
@@ -137,6 +137,7 @@ new HttpSocketClientConfig { Url = new Uri("http://localhost:5000/nexus") };
 | `AcceptorBacklog` | 20 | Listen backlog |
 | `Authenticate` | false | Require client auth |
 | `RateLimiting` | null | `ConnectionRateLimitConfig`; null = disabled |
+| `AuthorizationCacheDuration` | null | Default auth cache TTL; null = disabled |
 
 ### TCP options (TcpServerConfig/TcpClientConfig)
 
@@ -267,6 +268,77 @@ protected override ValueTask<IIdentity?> OnAuthenticate(ReadOnlyMemory<byte>? to
 // Client config
 var clientConfig = new TcpClientConfig { EndPoint = ep, Authenticate = () => Encoding.UTF8.GetBytes("valid") };
 ```
+
+## Authorization
+
+Declarative method/collection authorization via `[NexusAuthorize<TPermission>]`. Server-only. Permission enum must be backed by `int` (default).
+
+```csharp
+// 1. Define permission enum
+public enum Permission { Read, Write, Admin }
+
+// 2. Decorate methods on the server nexus class
+[NexusAuthorize<Permission>(Permission.Admin)]
+public ValueTask AdminMethod() { ... }
+
+[NexusAuthorize<Permission>(Permission.Read, Permission.Write)]
+public ValueTask MultiPermMethod() { ... }
+
+[NexusAuthorize<Permission>()]  // marker-only: requires auth, no specific permission
+public ValueTask AnyAuthMethod() { ... }
+
+// 3. Decorate collections on the interface
+public partial interface IServerNexus {
+    [NexusCollection(NexusCollectionMode.ServerToClient)]
+    [NexusAuthorize<Permission>(Permission.Read)]
+    INexusList<string> SecureItems { get; }
+}
+
+// 4. Override OnAuthorize on the server nexus
+protected override ValueTask<AuthorizeResult> OnAuthorize(
+    ServerSessionContext<ClientProxy> context, int methodId,
+    string methodName, ReadOnlyMemory<int> requiredPermissions)
+{
+    // requiredPermissions contains int-cast enum values
+    // Return: Allowed, Unauthorized (error to client), Disconnect (kill session)
+    var user = context.Identity;
+    return new(HasPermissions(user, requiredPermissions)
+        ? AuthorizeResult.Allowed : AuthorizeResult.Unauthorized);
+}
+
+// 5. Client-side: catch ProxyUnauthorizedException
+try { await client.Proxy.AdminMethod(); }
+catch (ProxyUnauthorizedException) { /* denied */ }
+```
+
+Auth guard runs before deserialization. If `OnAuthorize` throws, session disconnects (fail-safe). Collections use `Disconnect` for unauthorized access since they lack a return channel.
+
+### Authorization Caching
+
+Opt-in TTL-based caching per session. Only `Allowed` and `Unauthorized` results are cached; `Disconnect` and exceptions are never cached.
+
+```csharp
+// Server-wide default (null = disabled)
+serverConfig.AuthorizationCacheDuration = TimeSpan.FromSeconds(30);
+
+// Per-method override via attribute (-1 = use server config, 0 = never cache, >0 = seconds)
+[NexusAuthorize<Permission>(Permission.Read, CacheDurationSeconds = 60)]   // 60s override
+[NexusAuthorize<Permission>(Permission.Admin, CacheDurationSeconds = 0)]   // never cache
+[NexusAuthorize<Permission>(Permission.Write)]                              // use server default
+
+// Explicit invalidation (inside nexus methods)
+InvalidateAuthorizationCache();           // clear all cached results
+InvalidateAuthorizationCache(methodId);   // clear single method
+```
+
+### Diagnostics
+
+| ID | Description |
+|---|---|
+| NEXNET024 | `[NexusAuthorize]` on client nexus (server-only) |
+| NEXNET025 | `[NexusAuthorize]` without `OnAuthorize` override |
+| NEXNET026 | Mixed permission enum types across attributes |
+| NEXNET027 | Permission enum not backed by `int` |
 
 ## Duplex Pipes (Byte Streaming)
 

--- a/src/NexNet.Generator.Tests/GeneratorAuthorizationTests.cs
+++ b/src/NexNet.Generator.Tests/GeneratorAuthorizationTests.cs
@@ -1,0 +1,237 @@
+using Microsoft.CodeAnalysis;
+using NUnit.Framework;
+
+namespace NexNet.Generator.Tests;
+
+class GeneratorAuthorizationTests
+{
+    private const string AuthPreamble = """
+using NexNet;
+using System;
+using System.Threading.Tasks;
+namespace NexNetDemo;
+
+public enum TestPermission { Read, Write, Admin }
+partial interface IAuthClientNexus { }
+partial interface IAuthServerNexus
+{
+    ValueTask ProtectedMethod(string input);
+    ValueTask AdminMethod();
+    ValueTask UnprotectedMethod();
+}
+""";
+
+    [Test]
+    public void AuthorizeOnClientNexus_EmitsError()
+    {
+        var diagnostics = CSharpGeneratorRunner.RunGenerator($$"""
+using NexNet;
+using System;
+using System.Threading.Tasks;
+namespace NexNetDemo;
+
+public enum TestPermission { Read, Write, Admin }
+partial interface IClientNexus
+{
+    ValueTask DoWork();
+}
+partial interface IServerNexus { }
+
+[Nexus<IClientNexus, IServerNexus>(NexusType = NexusType.Client)]
+partial class ClientNexus
+{
+    [NexusAuthorize<TestPermission>(TestPermission.Write)]
+    public ValueTask DoWork() => ValueTask.CompletedTask;
+}
+
+[Nexus<IServerNexus, IClientNexus>(NexusType = NexusType.Server)]
+partial class ServerNexus { }
+""");
+        Assert.That(diagnostics.Any(d => d.Id == DiagnosticDescriptors.AuthorizeOnClientNexus.Id), Is.True);
+    }
+
+    [Test]
+    public void AuthorizeWithoutOnAuthorize_EmitsWarning()
+    {
+        var diagnostics = CSharpGeneratorRunner.RunGenerator(AuthPreamble + """
+
+[Nexus<IAuthClientNexus, IAuthServerNexus>(NexusType = NexusType.Client)]
+partial class AuthClientNexus { }
+
+[Nexus<IAuthServerNexus, IAuthClientNexus>(NexusType = NexusType.Server)]
+partial class AuthServerNexus
+{
+    [NexusAuthorize<TestPermission>(TestPermission.Write)]
+    public ValueTask ProtectedMethod(string input) => ValueTask.CompletedTask;
+
+    public ValueTask AdminMethod() => ValueTask.CompletedTask;
+    public ValueTask UnprotectedMethod() => ValueTask.CompletedTask;
+}
+""", minDiagnostic: DiagnosticSeverity.Warning);
+        Assert.That(diagnostics.Any(d => d.Id == DiagnosticDescriptors.AuthorizeWithoutOnAuthorize.Id), Is.True);
+    }
+
+    [Test]
+    public void AuthorizeWithOnAuthorize_NoWarning()
+    {
+        var diagnostics = CSharpGeneratorRunner.RunGenerator(AuthPreamble + """
+
+[Nexus<IAuthClientNexus, IAuthServerNexus>(NexusType = NexusType.Client)]
+partial class AuthClientNexus { }
+
+[Nexus<IAuthServerNexus, IAuthClientNexus>(NexusType = NexusType.Server)]
+partial class AuthServerNexus
+{
+    [NexusAuthorize<TestPermission>(TestPermission.Write)]
+    public ValueTask ProtectedMethod(string input) => ValueTask.CompletedTask;
+
+    public ValueTask AdminMethod() => ValueTask.CompletedTask;
+    public ValueTask UnprotectedMethod() => ValueTask.CompletedTask;
+
+    protected override ValueTask<AuthorizeResult> OnAuthorize(
+        NexNet.Invocation.ServerSessionContext<AuthServerNexus.ClientProxy> context,
+        int methodId, string methodName, ReadOnlyMemory<int> requiredPermissions)
+        => new(AuthorizeResult.Allowed);
+}
+""", minDiagnostic: DiagnosticSeverity.Warning);
+        Assert.That(diagnostics.Any(d => d.Id == DiagnosticDescriptors.AuthorizeWithoutOnAuthorize.Id), Is.False);
+    }
+
+    [Test]
+    public void MixedPermissionEnums_EmitsError()
+    {
+        var diagnostics = CSharpGeneratorRunner.RunGenerator("""
+using NexNet;
+using System;
+using System.Threading.Tasks;
+namespace NexNetDemo;
+
+public enum PermA { X }
+public enum PermB { Y }
+partial interface IClientNexus { }
+partial interface IServerNexus
+{
+    ValueTask MethodA();
+    ValueTask MethodB();
+}
+
+[Nexus<IClientNexus, IServerNexus>(NexusType = NexusType.Client)]
+partial class ClientNexus { }
+
+[Nexus<IServerNexus, IClientNexus>(NexusType = NexusType.Server)]
+partial class ServerNexus
+{
+    [NexusAuthorize<PermA>(PermA.X)]
+    public ValueTask MethodA() => ValueTask.CompletedTask;
+
+    [NexusAuthorize<PermB>(PermB.Y)]
+    public ValueTask MethodB() => ValueTask.CompletedTask;
+}
+""");
+        Assert.That(diagnostics.Any(d => d.Id == DiagnosticDescriptors.MixedPermissionEnumTypes.Id), Is.True);
+    }
+
+    [Test]
+    public void NoAuthorize_NoDiagnostics()
+    {
+        var diagnostics = CSharpGeneratorRunner.RunGenerator(AuthPreamble + """
+
+[Nexus<IAuthClientNexus, IAuthServerNexus>(NexusType = NexusType.Client)]
+partial class AuthClientNexus { }
+
+[Nexus<IAuthServerNexus, IAuthClientNexus>(NexusType = NexusType.Server)]
+partial class AuthServerNexus
+{
+    public ValueTask ProtectedMethod(string input) => ValueTask.CompletedTask;
+    public ValueTask AdminMethod() => ValueTask.CompletedTask;
+    public ValueTask UnprotectedMethod() => ValueTask.CompletedTask;
+}
+""", minDiagnostic: DiagnosticSeverity.Warning);
+        Assert.That(diagnostics.Any(d =>
+            d.Id == DiagnosticDescriptors.AuthorizeOnClientNexus.Id ||
+            d.Id == DiagnosticDescriptors.AuthorizeWithoutOnAuthorize.Id ||
+            d.Id == DiagnosticDescriptors.MixedPermissionEnumTypes.Id), Is.False);
+    }
+
+    [Test]
+    public void AuthorizedMethod_GeneratesSuccessfully()
+    {
+        // Verify the generator produces compilable code with auth guards
+        var diagnostics = CSharpGeneratorRunner.RunGenerator(AuthPreamble + """
+
+[Nexus<IAuthClientNexus, IAuthServerNexus>(NexusType = NexusType.Client)]
+partial class AuthClientNexus { }
+
+[Nexus<IAuthServerNexus, IAuthClientNexus>(NexusType = NexusType.Server)]
+partial class AuthServerNexus
+{
+    [NexusAuthorize<TestPermission>(TestPermission.Write)]
+    public ValueTask ProtectedMethod(string input) => ValueTask.CompletedTask;
+
+    [NexusAuthorize<TestPermission>(TestPermission.Admin)]
+    public ValueTask AdminMethod() => ValueTask.CompletedTask;
+
+    public ValueTask UnprotectedMethod() => ValueTask.CompletedTask;
+
+    protected override ValueTask<AuthorizeResult> OnAuthorize(
+        NexNet.Invocation.ServerSessionContext<AuthServerNexus.ClientProxy> context,
+        int methodId, string methodName, ReadOnlyMemory<int> requiredPermissions)
+        => new(AuthorizeResult.Allowed);
+}
+""");
+        // No errors means generated code compiled successfully
+        Assert.That(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error), Is.Empty);
+    }
+
+    [Test]
+    public void MarkerOnlyAuthorize_GeneratesSuccessfully()
+    {
+        var diagnostics = CSharpGeneratorRunner.RunGenerator(AuthPreamble + """
+
+[Nexus<IAuthClientNexus, IAuthServerNexus>(NexusType = NexusType.Client)]
+partial class AuthClientNexus { }
+
+[Nexus<IAuthServerNexus, IAuthClientNexus>(NexusType = NexusType.Server)]
+partial class AuthServerNexus
+{
+    [NexusAuthorize<TestPermission>()]
+    public ValueTask ProtectedMethod(string input) => ValueTask.CompletedTask;
+
+    public ValueTask AdminMethod() => ValueTask.CompletedTask;
+    public ValueTask UnprotectedMethod() => ValueTask.CompletedTask;
+
+    protected override ValueTask<AuthorizeResult> OnAuthorize(
+        NexNet.Invocation.ServerSessionContext<AuthServerNexus.ClientProxy> context,
+        int methodId, string methodName, ReadOnlyMemory<int> requiredPermissions)
+        => new(AuthorizeResult.Allowed);
+}
+""");
+        Assert.That(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error), Is.Empty);
+    }
+
+    [Test]
+    public void MultiplePermissions_GeneratesSuccessfully()
+    {
+        var diagnostics = CSharpGeneratorRunner.RunGenerator(AuthPreamble + """
+
+[Nexus<IAuthClientNexus, IAuthServerNexus>(NexusType = NexusType.Client)]
+partial class AuthClientNexus { }
+
+[Nexus<IAuthServerNexus, IAuthClientNexus>(NexusType = NexusType.Server)]
+partial class AuthServerNexus
+{
+    [NexusAuthorize<TestPermission>(TestPermission.Read, TestPermission.Write, TestPermission.Admin)]
+    public ValueTask ProtectedMethod(string input) => ValueTask.CompletedTask;
+
+    public ValueTask AdminMethod() => ValueTask.CompletedTask;
+    public ValueTask UnprotectedMethod() => ValueTask.CompletedTask;
+
+    protected override ValueTask<AuthorizeResult> OnAuthorize(
+        NexNet.Invocation.ServerSessionContext<AuthServerNexus.ClientProxy> context,
+        int methodId, string methodName, ReadOnlyMemory<int> requiredPermissions)
+        => new(AuthorizeResult.Allowed);
+}
+""");
+        Assert.That(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error), Is.Empty);
+    }
+}

--- a/src/NexNet.Generator.Tests/GeneratorAuthorizationTests.cs
+++ b/src/NexNet.Generator.Tests/GeneratorAuthorizationTests.cs
@@ -234,4 +234,145 @@ partial class AuthServerNexus
 """);
         Assert.That(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error), Is.Empty);
     }
+
+    [Test]
+    public void AuthorizeOnCollection_GeneratesSuccessfully()
+    {
+        var diagnostics = CSharpGeneratorRunner.RunGenerator("""
+using NexNet;
+using NexNet.Collections;
+using NexNet.Collections.Lists;
+using System;
+using System.Threading.Tasks;
+namespace NexNetDemo;
+
+public enum TestPermission { Read, Write, Admin }
+partial interface IClientNexus { }
+partial interface IServerNexus
+{
+    [NexusCollection(NexusCollectionMode.ServerToClient)]
+    [NexusAuthorize<TestPermission>(TestPermission.Admin)]
+    INexusList<string> SecureItems { get; }
+}
+
+[Nexus<IClientNexus, IServerNexus>(NexusType = NexusType.Client)]
+partial class ClientNexus { }
+
+[Nexus<IServerNexus, IClientNexus>(NexusType = NexusType.Server)]
+partial class ServerNexus
+{
+    protected override ValueTask<AuthorizeResult> OnAuthorize(
+        NexNet.Invocation.ServerSessionContext<ServerNexus.ClientProxy> context,
+        int methodId, string methodName, ReadOnlyMemory<int> requiredPermissions)
+        => new(AuthorizeResult.Allowed);
+}
+""");
+        Assert.That(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error), Is.Empty);
+    }
+
+    [Test]
+    public void AuthorizeOnClientCollection_EmitsError()
+    {
+        var diagnostics = CSharpGeneratorRunner.RunGenerator("""
+using NexNet;
+using NexNet.Collections;
+using NexNet.Collections.Lists;
+using System;
+using System.Threading.Tasks;
+namespace NexNetDemo;
+
+public enum TestPermission { Read, Write, Admin }
+partial interface IClientNexus
+{
+    ValueTask DoWork();
+}
+partial interface IServerNexus
+{
+    [NexusCollection(NexusCollectionMode.ServerToClient)]
+    [NexusAuthorize<TestPermission>(TestPermission.Admin)]
+    INexusList<string> SecureItems { get; }
+}
+
+[Nexus<IClientNexus, IServerNexus>(NexusType = NexusType.Client)]
+partial class ClientNexus
+{
+    public ValueTask DoWork() => ValueTask.CompletedTask;
+}
+
+[Nexus<IServerNexus, IClientNexus>(NexusType = NexusType.Server)]
+partial class ServerNexus { }
+""");
+        // The server nexus has no OnAuthorize, but more importantly the NEXNET024 check
+        // applies to client nexus. Since collection auth is on the server interface here,
+        // it should trigger NEXNET025 (no OnAuthorize) but not NEXNET024.
+        // For a true client nexus auth error, we'd need auth on the client interface,
+        // but collections can't be on client anyway (NEXNET020).
+        // This test verifies that collection auth on server without OnAuthorize triggers NEXNET025.
+        Assert.That(diagnostics.Any(d => d.Id == DiagnosticDescriptors.AuthorizeWithoutOnAuthorize.Id), Is.True);
+    }
+
+    [Test]
+    public void CollectionAndMethodMixedEnums_EmitsError()
+    {
+        var diagnostics = CSharpGeneratorRunner.RunGenerator("""
+using NexNet;
+using NexNet.Collections;
+using NexNet.Collections.Lists;
+using System;
+using System.Threading.Tasks;
+namespace NexNetDemo;
+
+public enum PermA { X }
+public enum PermB { Y }
+partial interface IClientNexus { }
+partial interface IServerNexus
+{
+    ValueTask MethodA();
+
+    [NexusCollection(NexusCollectionMode.ServerToClient)]
+    [NexusAuthorize<PermB>(PermB.Y)]
+    INexusList<string> SecureItems { get; }
+}
+
+[Nexus<IClientNexus, IServerNexus>(NexusType = NexusType.Client)]
+partial class ClientNexus { }
+
+[Nexus<IServerNexus, IClientNexus>(NexusType = NexusType.Server)]
+partial class ServerNexus
+{
+    [NexusAuthorize<PermA>(PermA.X)]
+    public ValueTask MethodA() => ValueTask.CompletedTask;
+}
+""");
+        Assert.That(diagnostics.Any(d => d.Id == DiagnosticDescriptors.MixedPermissionEnumTypes.Id), Is.True);
+    }
+
+    [Test]
+    public void AuthorizeOnCollection_WithoutOnAuthorize_EmitsWarning()
+    {
+        var diagnostics = CSharpGeneratorRunner.RunGenerator("""
+using NexNet;
+using NexNet.Collections;
+using NexNet.Collections.Lists;
+using System;
+using System.Threading.Tasks;
+namespace NexNetDemo;
+
+public enum TestPermission { Read, Write, Admin }
+partial interface IClientNexus { }
+partial interface IServerNexus
+{
+    [NexusCollection(NexusCollectionMode.ServerToClient)]
+    [NexusAuthorize<TestPermission>(TestPermission.Admin)]
+    INexusList<string> SecureItems { get; }
+}
+
+[Nexus<IClientNexus, IServerNexus>(NexusType = NexusType.Client)]
+partial class ClientNexus { }
+
+[Nexus<IServerNexus, IClientNexus>(NexusType = NexusType.Server)]
+partial class ServerNexus { }
+""", minDiagnostic: DiagnosticSeverity.Warning);
+        Assert.That(diagnostics.Any(d => d.Id == DiagnosticDescriptors.AuthorizeWithoutOnAuthorize.Id), Is.True);
+    }
 }

--- a/src/NexNet.Generator.Tests/GeneratorAuthorizationTests.cs
+++ b/src/NexNet.Generator.Tests/GeneratorAuthorizationTests.cs
@@ -236,6 +236,58 @@ partial class AuthServerNexus
     }
 
     [Test]
+    public void AuthorizeWithCacheDuration_GeneratesSuccessfully()
+    {
+        var diagnostics = CSharpGeneratorRunner.RunGenerator(AuthPreamble + """
+
+[Nexus<IAuthClientNexus, IAuthServerNexus>(NexusType = NexusType.Client)]
+partial class AuthClientNexus { }
+
+[Nexus<IAuthServerNexus, IAuthClientNexus>(NexusType = NexusType.Server)]
+partial class AuthServerNexus
+{
+    [NexusAuthorize<TestPermission>(TestPermission.Write, CacheDurationSeconds = 60)]
+    public ValueTask ProtectedMethod(string input) => ValueTask.CompletedTask;
+
+    public ValueTask AdminMethod() => ValueTask.CompletedTask;
+    public ValueTask UnprotectedMethod() => ValueTask.CompletedTask;
+
+    protected override ValueTask<AuthorizeResult> OnAuthorize(
+        NexNet.Invocation.ServerSessionContext<AuthServerNexus.ClientProxy> context,
+        int methodId, string methodName, ReadOnlyMemory<int> requiredPermissions)
+        => new(AuthorizeResult.Allowed);
+}
+""");
+        Assert.That(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error), Is.Empty);
+    }
+
+    [Test]
+    public void AuthorizeWithCacheDurationZero_GeneratesSuccessfully()
+    {
+        var diagnostics = CSharpGeneratorRunner.RunGenerator(AuthPreamble + """
+
+[Nexus<IAuthClientNexus, IAuthServerNexus>(NexusType = NexusType.Client)]
+partial class AuthClientNexus { }
+
+[Nexus<IAuthServerNexus, IAuthClientNexus>(NexusType = NexusType.Server)]
+partial class AuthServerNexus
+{
+    [NexusAuthorize<TestPermission>(TestPermission.Write, CacheDurationSeconds = 0)]
+    public ValueTask ProtectedMethod(string input) => ValueTask.CompletedTask;
+
+    public ValueTask AdminMethod() => ValueTask.CompletedTask;
+    public ValueTask UnprotectedMethod() => ValueTask.CompletedTask;
+
+    protected override ValueTask<AuthorizeResult> OnAuthorize(
+        NexNet.Invocation.ServerSessionContext<AuthServerNexus.ClientProxy> context,
+        int methodId, string methodName, ReadOnlyMemory<int> requiredPermissions)
+        => new(AuthorizeResult.Allowed);
+}
+""");
+        Assert.That(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error), Is.Empty);
+    }
+
+    [Test]
     public void AuthorizeOnCollection_GeneratesSuccessfully()
     {
         var diagnostics = CSharpGeneratorRunner.RunGenerator("""
@@ -251,7 +303,7 @@ partial interface IClientNexus { }
 partial interface IServerNexus
 {
     [NexusCollection(NexusCollectionMode.ServerToClient)]
-    [NexusAuthorize<TestPermission>(TestPermission.Admin)]
+    [NexusAuthorize<TestPermission>(TestPermission.Admin, CacheDurationSeconds = 120)]
     INexusList<string> SecureItems { get; }
 }
 

--- a/src/NexNet.Generator.Tests/GeneratorAuthorizationTests.cs
+++ b/src/NexNet.Generator.Tests/GeneratorAuthorizationTests.cs
@@ -51,7 +51,7 @@ partial class ServerNexus { }
     }
 
     [Test]
-    public void AuthorizeWithoutOnAuthorize_EmitsWarning()
+    public void AuthorizeWithoutOnAuthorize_EmitsError()
     {
         var diagnostics = CSharpGeneratorRunner.RunGenerator(AuthPreamble + """
 
@@ -422,6 +422,40 @@ partial class ClientNexus { }
 partial class ServerNexus
 {
     [NexusAuthorize<LongPerm>(LongPerm.Read)]
+    public ValueTask DoWork() => ValueTask.CompletedTask;
+
+    protected override ValueTask<AuthorizeResult> OnAuthorize(
+        NexNet.Invocation.ServerSessionContext<ServerNexus.ClientProxy> context,
+        int methodId, string methodName, ReadOnlyMemory<int> requiredPermissions)
+        => new(AuthorizeResult.Allowed);
+}
+""");
+        Assert.That(diagnostics.Any(d => d.Id == DiagnosticDescriptors.AuthorizeEnumUnderlyingTypeIncompatible.Id), Is.True);
+    }
+
+    [Test]
+    public void AuthorizeWithByteEnum_EmitsError()
+    {
+        var diagnostics = CSharpGeneratorRunner.RunGenerator("""
+using NexNet;
+using System;
+using System.Threading.Tasks;
+namespace NexNetDemo;
+
+public enum BytePerm : byte { Read, Write }
+partial interface IClientNexus { }
+partial interface IServerNexus
+{
+    ValueTask DoWork();
+}
+
+[Nexus<IClientNexus, IServerNexus>(NexusType = NexusType.Client)]
+partial class ClientNexus { }
+
+[Nexus<IServerNexus, IClientNexus>(NexusType = NexusType.Server)]
+partial class ServerNexus
+{
+    [NexusAuthorize<BytePerm>(BytePerm.Read)]
     public ValueTask DoWork() => ValueTask.CompletedTask;
 
     protected override ValueTask<AuthorizeResult> OnAuthorize(

--- a/src/NexNet.Generator.Tests/GeneratorAuthorizationTests.cs
+++ b/src/NexNet.Generator.Tests/GeneratorAuthorizationTests.cs
@@ -348,6 +348,66 @@ partial class ServerNexus
     }
 
     [Test]
+    public void AuthorizeWithLongEnum_EmitsError()
+    {
+        var diagnostics = CSharpGeneratorRunner.RunGenerator("""
+using NexNet;
+using System;
+using System.Threading.Tasks;
+namespace NexNetDemo;
+
+public enum LongPerm : long { Read, Write }
+partial interface IClientNexus { }
+partial interface IServerNexus
+{
+    ValueTask DoWork();
+}
+
+[Nexus<IClientNexus, IServerNexus>(NexusType = NexusType.Client)]
+partial class ClientNexus { }
+
+[Nexus<IServerNexus, IClientNexus>(NexusType = NexusType.Server)]
+partial class ServerNexus
+{
+    [NexusAuthorize<LongPerm>(LongPerm.Read)]
+    public ValueTask DoWork() => ValueTask.CompletedTask;
+
+    protected override ValueTask<AuthorizeResult> OnAuthorize(
+        NexNet.Invocation.ServerSessionContext<ServerNexus.ClientProxy> context,
+        int methodId, string methodName, ReadOnlyMemory<int> requiredPermissions)
+        => new(AuthorizeResult.Allowed);
+}
+""");
+        Assert.That(diagnostics.Any(d => d.Id == DiagnosticDescriptors.AuthorizeEnumUnderlyingTypeIncompatible.Id), Is.True);
+    }
+
+    [Test]
+    public void AuthorizeWithIntEnum_NoDiagnostic()
+    {
+        var diagnostics = CSharpGeneratorRunner.RunGenerator(AuthPreamble + """
+
+[Nexus<IAuthClientNexus, IAuthServerNexus>(NexusType = NexusType.Client)]
+partial class AuthClientNexus { }
+
+[Nexus<IAuthServerNexus, IAuthClientNexus>(NexusType = NexusType.Server)]
+partial class AuthServerNexus
+{
+    [NexusAuthorize<TestPermission>(TestPermission.Write)]
+    public ValueTask ProtectedMethod(string input) => ValueTask.CompletedTask;
+
+    public ValueTask AdminMethod() => ValueTask.CompletedTask;
+    public ValueTask UnprotectedMethod() => ValueTask.CompletedTask;
+
+    protected override ValueTask<AuthorizeResult> OnAuthorize(
+        NexNet.Invocation.ServerSessionContext<AuthServerNexus.ClientProxy> context,
+        int methodId, string methodName, ReadOnlyMemory<int> requiredPermissions)
+        => new(AuthorizeResult.Allowed);
+}
+""");
+        Assert.That(diagnostics.Any(d => d.Id == DiagnosticDescriptors.AuthorizeEnumUnderlyingTypeIncompatible.Id), Is.False);
+    }
+
+    [Test]
     public void AuthorizeOnCollection_WithoutOnAuthorize_EmitsWarning()
     {
         var diagnostics = CSharpGeneratorRunner.RunGenerator("""

--- a/src/NexNet.Generator/DiagnosticDescriptors.cs
+++ b/src/NexNet.Generator/DiagnosticDescriptors.cs
@@ -203,7 +203,7 @@ internal static class DiagnosticDescriptors
         title: "NexusAuthorize used but OnAuthorize is not overridden",
         messageFormat: "The nexus '{0}' uses [NexusAuthorize] but does not override OnAuthorize. All invocations will be allowed by default.",
         category: Category,
-        defaultSeverity: DiagnosticSeverity.Warning,
+        defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
     public static readonly DiagnosticDescriptor MixedPermissionEnumTypes = new(

--- a/src/NexNet.Generator/DiagnosticDescriptors.cs
+++ b/src/NexNet.Generator/DiagnosticDescriptors.cs
@@ -189,6 +189,30 @@ internal static class DiagnosticDescriptors
         category: Category,
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor AuthorizeOnClientNexus = new(
+        id: "NEXNET024",
+        title: "NexusAuthorize is only supported on server nexuses",
+        messageFormat: "The method '{0}' uses [NexusAuthorize] but the nexus is a client nexus. Authorization is only supported on server nexuses.",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor AuthorizeWithoutOnAuthorize = new(
+        id: "NEXNET025",
+        title: "NexusAuthorize used but OnAuthorize is not overridden",
+        messageFormat: "The nexus '{0}' uses [NexusAuthorize] but does not override OnAuthorize. All invocations will be allowed by default.",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor MixedPermissionEnumTypes = new(
+        id: "NEXNET026",
+        title: "All NexusAuthorize attributes must use the same permission enum type",
+        messageFormat: "The nexus '{0}' uses [NexusAuthorize] with mixed permission enum types. All attributes must use the same TPermission type.",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
 }
 
 

--- a/src/NexNet.Generator/DiagnosticDescriptors.cs
+++ b/src/NexNet.Generator/DiagnosticDescriptors.cs
@@ -216,8 +216,8 @@ internal static class DiagnosticDescriptors
 
     public static readonly DiagnosticDescriptor AuthorizeEnumUnderlyingTypeIncompatible = new(
         id: "NEXNET027",
-        title: "NexusAuthorize permission enum underlying type must fit in Int32",
-        messageFormat: "The method '{0}' uses [NexusAuthorize] with a permission enum whose underlying type is Int64 or UInt64. Permission values are stored as Int32 and may overflow. Use an enum backed by int or smaller.",
+        title: "NexusAuthorize permission enum must be backed by int",
+        messageFormat: "The method '{0}' uses [NexusAuthorize] with a permission enum that is not backed by int. Permission values are stored as Int32. Use an enum backed by int (the default).",
         category: Category,
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);

--- a/src/NexNet.Generator/DiagnosticDescriptors.cs
+++ b/src/NexNet.Generator/DiagnosticDescriptors.cs
@@ -213,6 +213,14 @@ internal static class DiagnosticDescriptors
         category: Category,
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor AuthorizeEnumUnderlyingTypeIncompatible = new(
+        id: "NEXNET027",
+        title: "NexusAuthorize permission enum underlying type must fit in Int32",
+        messageFormat: "The method '{0}' uses [NexusAuthorize] with a permission enum whose underlying type is Int64 or UInt64. Permission values are stored as Int32 and may overflow. Use an enum backed by int or smaller.",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
 }
 
 

--- a/src/NexNet.Generator/Emission/CollectionEmitter.cs
+++ b/src/NexNet.Generator/Emission/CollectionEmitter.cs
@@ -46,6 +46,18 @@ internal static class CollectionEmitter
     /// </summary>
     public static void EmitNexusInvocation(StringBuilder sb, CollectionData collection)
     {
+        // Emit auth guard before any deserialization
+        if (collection.AuthorizeData != null)
+        {
+            sb.AppendLine();
+            sb.AppendLine("                        if (!await this.CheckAuthorization(");
+            sb.Append("                            ").Append(collection.Id)
+                .Append(", \"").Append(collection.Name).Append("\", __authPerms_").Append(collection.Name).AppendLine(",");
+            sb.AppendLine("                            message.InvocationId,");
+            sb.AppendLine("                            returnBuffer != null).ConfigureAwait(false))");
+            sb.AppendLine("                            return;");
+        }
+
         sb.Append(@"
                         var arguments = message.DeserializeArguments<global::System.ValueTuple<global::System.Byte>>();
                         duplexPipe = await methodInvoker.RegisterDuplexPipe(arguments.Item1).ConfigureAwait(false);

--- a/src/NexNet.Generator/Emission/CollectionEmitter.cs
+++ b/src/NexNet.Generator/Emission/CollectionEmitter.cs
@@ -52,7 +52,7 @@ internal static class CollectionEmitter
             sb.AppendLine();
             sb.AppendLine("                        if (!await this.CheckAuthorization(");
             sb.Append("                            ").Append(collection.Id)
-                .Append(", \"").Append(collection.Name).Append("\", __authPerms_").Append(collection.Name).AppendLine(",");
+                .Append(", \"").Append(collection.Name).Append("\", __authPerms_").Append(collection.Id).AppendLine(",");
             sb.AppendLine("                            message.InvocationId,");
             sb.Append("                            returnBuffer != null, ").Append(collection.AuthorizeData!.CacheDurationSeconds).AppendLine(").ConfigureAwait(false))");
             sb.AppendLine("                            return;");

--- a/src/NexNet.Generator/Emission/CollectionEmitter.cs
+++ b/src/NexNet.Generator/Emission/CollectionEmitter.cs
@@ -54,7 +54,7 @@ internal static class CollectionEmitter
             sb.Append("                            ").Append(collection.Id)
                 .Append(", \"").Append(collection.Name).Append("\", __authPerms_").Append(collection.Name).AppendLine(",");
             sb.AppendLine("                            message.InvocationId,");
-            sb.AppendLine("                            returnBuffer != null).ConfigureAwait(false))");
+            sb.Append("                            returnBuffer != null, ").Append(collection.AuthorizeData!.CacheDurationSeconds).AppendLine(").ConfigureAwait(false))");
             sb.AppendLine("                            return;");
         }
 

--- a/src/NexNet.Generator/Emission/MethodEmitter.cs
+++ b/src/NexNet.Generator/Emission/MethodEmitter.cs
@@ -21,25 +21,13 @@ internal static class MethodEmitter
         if (method.AuthorizeData != null)
         {
             sb.AppendLine($$"""
-                        var __authResult = await this.Authorize(
+                        if (!await this.CheckAuthorization(
                             {{method.Id}},
                             "{{method.Name}}",
-                            __authPerms_{{method.Name}}).ConfigureAwait(false);
-
-                        if (__authResult == global::NexNet.AuthorizeResult.Disconnect)
-                        {
-                            await this.Context.Session.DisconnectAsync(global::NexNet.Messages.DisconnectReason.Unauthorized).ConfigureAwait(false);
+                            __authPerms_{{method.Name}},
+                            message.InvocationId,
+                            returnBuffer != null).ConfigureAwait(false))
                             return;
-                        }
-
-                        if (__authResult == global::NexNet.AuthorizeResult.Unauthorized)
-                        {
-                            if (returnBuffer != null)
-                            {
-                                await this.SendUnauthorizedResult(message.InvocationId).ConfigureAwait(false);
-                            }
-                            return;
-                        }
 """);
         }
 

--- a/src/NexNet.Generator/Emission/MethodEmitter.cs
+++ b/src/NexNet.Generator/Emission/MethodEmitter.cs
@@ -26,7 +26,8 @@ internal static class MethodEmitter
                             "{{method.Name}}",
                             __authPerms_{{method.Name}},
                             message.InvocationId,
-                            returnBuffer != null).ConfigureAwait(false))
+                            returnBuffer != null,
+                            {{method.AuthorizeData!.CacheDurationSeconds}}).ConfigureAwait(false))
                             return;
 """);
         }

--- a/src/NexNet.Generator/Emission/MethodEmitter.cs
+++ b/src/NexNet.Generator/Emission/MethodEmitter.cs
@@ -24,7 +24,7 @@ internal static class MethodEmitter
                         if (!await this.CheckAuthorization(
                             {{method.Id}},
                             "{{method.Name}}",
-                            __authPerms_{{method.Name}},
+                            __authPerms_{{method.Id}},
                             message.InvocationId,
                             returnBuffer != null,
                             {{method.AuthorizeData!.CacheDurationSeconds}}).ConfigureAwait(false))

--- a/src/NexNet.Generator/Emission/NexusEmitter.cs
+++ b/src/NexNet.Generator/Emission/NexusEmitter.cs
@@ -101,6 +101,30 @@ internal static class NexusEmitter
                             """);
         }
 
+        // Emit static permission arrays for authorized methods
+        foreach (var method in data.NexusInterface.AllMethods)
+        {
+            if (method.AuthorizeData != null)
+            {
+                if (method.AuthorizeData.Permissions.Length == 0)
+                {
+                    sb.Append("        private static readonly int[] __authPerms_").Append(method.Name)
+                        .AppendLine(" = global::System.Array.Empty<int>();");
+                }
+                else
+                {
+                    sb.Append("        private static readonly int[] __authPerms_").Append(method.Name)
+                        .Append(" = new int[] { ");
+                    foreach (var perm in method.AuthorizeData.Permissions)
+                    {
+                        sb.Append(perm).Append(", ");
+                    }
+                    sb.Remove(sb.Length - 2, 2);
+                    sb.AppendLine(" };");
+                }
+            }
+        }
+
         sb.AppendLine($$"""
 
                                 protected override async global::System.Threading.Tasks.ValueTask InvokeMethodCore(global::NexNet.Messages.IInvocationMessage message, global::System.Buffers.IBufferWriter<byte>? returnBuffer)

--- a/src/NexNet.Generator/Emission/NexusEmitter.cs
+++ b/src/NexNet.Generator/Emission/NexusEmitter.cs
@@ -23,16 +23,16 @@ internal static class NexusEmitter
     private static string EmitServerClientName(NexusAttributeData attr) =>
         attr.IsServer ? "Server" : "Client";
 
-    private static void EmitAuthPermsField(StringBuilder sb, string name, Models.AuthorizeData authData)
+    private static void EmitAuthPermsField(StringBuilder sb, ushort id, Models.AuthorizeData authData)
     {
         if (authData.Permissions.Length == 0)
         {
-            sb.Append("        private static readonly int[] __authPerms_").Append(name)
+            sb.Append("        private static readonly int[] __authPerms_").Append(id)
                 .AppendLine(" = global::System.Array.Empty<int>();");
         }
         else
         {
-            sb.Append("        private static readonly int[] __authPerms_").Append(name)
+            sb.Append("        private static readonly int[] __authPerms_").Append(id)
                 .Append(" = new int[] { ");
             foreach (var perm in authData.Permissions)
             {
@@ -126,7 +126,7 @@ internal static class NexusEmitter
         {
             if (method.AuthorizeData != null)
             {
-                EmitAuthPermsField(sb, method.Name, method.AuthorizeData);
+                EmitAuthPermsField(sb, method.Id, method.AuthorizeData);
             }
         }
 
@@ -135,7 +135,7 @@ internal static class NexusEmitter
         {
             if (collection.AuthorizeData != null)
             {
-                EmitAuthPermsField(sb, collection.Name, collection.AuthorizeData);
+                EmitAuthPermsField(sb, collection.Id, collection.AuthorizeData);
             }
         }
 

--- a/src/NexNet.Generator/Extraction/NexusDataExtractor.cs
+++ b/src/NexNet.Generator/Extraction/NexusDataExtractor.cs
@@ -491,6 +491,7 @@ internal static class NexusDataExtractor
     {
         var collectionAttr = ExtractCollectionAttribute(symbol);
         var methodAttr = ExtractMethodAttributeFromProperty(symbol);
+        var authorizeData = ExtractAuthorizeData(symbol);
 
         var returnSymbol = symbol.Type as INamedTypeSymbol;
 
@@ -523,6 +524,7 @@ internal static class NexusDataExtractor
             CollectionType: collectionType,
             CollectionAttribute: collectionAttr,
             MethodAttribute: methodAttr,
+            AuthorizeData: authorizeData,
             Location: LocationData.FromSymbol(symbol)
         )
         {
@@ -530,9 +532,15 @@ internal static class NexusDataExtractor
         };
     }
 
+    private static AuthorizeData? ExtractAuthorizeData(IPropertySymbol symbol)
+        => ExtractAuthorizeDataFromAttributes(symbol.GetAttributes());
+
     private static AuthorizeData? ExtractAuthorizeData(IMethodSymbol symbol)
+        => ExtractAuthorizeDataFromAttributes(symbol.GetAttributes());
+
+    private static AuthorizeData? ExtractAuthorizeDataFromAttributes(ImmutableArray<AttributeData> attributes)
     {
-        var attr = symbol.GetAttributes()
+        var attr = attributes
             .FirstOrDefault(a => a.AttributeClass is { Name: "NexusAuthorizeAttribute", IsGenericType: true });
 
         if (attr?.AttributeClass is null)

--- a/src/NexNet.Generator/Extraction/NexusDataExtractor.cs
+++ b/src/NexNet.Generator/Extraction/NexusDataExtractor.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Immutable;
 using System.Text;
 using Microsoft.CodeAnalysis;
@@ -62,6 +63,16 @@ internal static class NexusDataExtractor
             .OfType<IMethodSymbol>()
             .Select(m => ExtractMethodData(m, typeHasher, 0)) // ID 0 for class methods since they're not invokable
             .ToImmutableArray();
+
+        // Correlate authorize data from class methods onto interface methods
+        var authByName = classMethods
+            .Where(m => m.AuthorizeData != null)
+            .ToDictionary(m => m.Name, m => m.AuthorizeData!);
+
+        if (authByName.Count > 0)
+        {
+            nexusInterface = ApplyAuthorizeDataToInterface(nexusInterface, authByName);
+        }
 
         var fullTypeName = symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)
             .Replace("global::", "")
@@ -377,6 +388,9 @@ internal static class NexusDataExtractor
         // Compute hash
         var hash = ComputeMethodHash(symbol, parameters, methodAttr);
 
+        // Extract authorize attribute
+        var authorizeData = ExtractAuthorizeData(symbol);
+
         return new MethodData(
             Name: symbol.Name,
             Id: assignedId,
@@ -399,6 +413,7 @@ internal static class NexusDataExtractor
             MultipleCancellationTokenParameters: multipleCancellationTokens,
             NexusHash: hash,
             MethodAttribute: methodAttr,
+            AuthorizeData: authorizeData,
             Location: LocationData.FromSymbol(symbol)
         );
     }
@@ -513,6 +528,39 @@ internal static class NexusDataExtractor
         {
             NexusHash = nexusHash
         };
+    }
+
+    private static AuthorizeData? ExtractAuthorizeData(IMethodSymbol symbol)
+    {
+        var attr = symbol.GetAttributes()
+            .FirstOrDefault(a => a.AttributeClass is { Name: "NexusAuthorizeAttribute", IsGenericType: true });
+
+        if (attr?.AttributeClass is null)
+            return null;
+
+        // Get the TPermission type argument
+        var permissionType = attr.AttributeClass.TypeArguments[0];
+        var permissionEnumFqn = permissionType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+
+        // Extract constructor arguments (the params TPermission[] permissions)
+        var permissions = ImmutableArray<int>.Empty;
+        if (attr.ConstructorArguments.Length > 0)
+        {
+            var arg = attr.ConstructorArguments[0];
+            if (arg.Kind == TypedConstantKind.Array && !arg.Values.IsDefaultOrEmpty)
+            {
+                permissions = arg.Values
+                    .Select(v => Convert.ToInt32(v.Value))
+                    .ToImmutableArray();
+            }
+            else if (arg.Kind == TypedConstantKind.Array)
+            {
+                // Empty params array
+                permissions = ImmutableArray<int>.Empty;
+            }
+        }
+
+        return new AuthorizeData(permissions, permissionEnumFqn);
     }
 
     private static NexusMethodAttributeData ExtractMethodAttribute(IMethodSymbol symbol)
@@ -698,6 +746,21 @@ internal static class NexusDataExtractor
             Hash: hash,
             Location: LocationData.FromSymbol(symbol)
         );
+    }
+
+    private static InvocationInterfaceData ApplyAuthorizeDataToInterface(
+        InvocationInterfaceData iface,
+        Dictionary<string, AuthorizeData> authByName)
+    {
+        var updatedMethods = iface.Methods
+            .Select(m => authByName.TryGetValue(m.Name, out var auth) ? m with { AuthorizeData = auth } : m)
+            .ToImmutableArray();
+
+        var updatedAllMethods = iface.AllMethods
+            .Select(m => authByName.TryGetValue(m.Name, out var auth) ? m with { AuthorizeData = auth } : m)
+            .ToImmutableArray();
+
+        return iface with { Methods = updatedMethods, AllMethods = updatedAllMethods };
     }
 
     private static void AssignMethodIds(MethodData[] methods)

--- a/src/NexNet.Generator/Extraction/NexusDataExtractor.cs
+++ b/src/NexNet.Generator/Extraction/NexusDataExtractor.cs
@@ -550,13 +550,11 @@ internal static class NexusDataExtractor
         var permissionType = attr.AttributeClass.TypeArguments[0];
         var permissionEnumFqn = permissionType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
 
-        // Check underlying type is compatible with int (long/ulong can overflow)
+        // Permission values are stored as int; only allow enums backed by int
         var isUnderlyingTypeCompatible = true;
         if (permissionType is INamedTypeSymbol namedPermType && namedPermType.EnumUnderlyingType != null)
         {
-            var underlying = namedPermType.EnumUnderlyingType.SpecialType;
-            if (underlying is SpecialType.System_Int64 or SpecialType.System_UInt64)
-                isUnderlyingTypeCompatible = false;
+            isUnderlyingTypeCompatible = namedPermType.EnumUnderlyingType.SpecialType == SpecialType.System_Int32;
         }
 
         // Extract constructor arguments (the params TPermission[] permissions)

--- a/src/NexNet.Generator/Extraction/NexusDataExtractor.cs
+++ b/src/NexNet.Generator/Extraction/NexusDataExtractor.cs
@@ -577,7 +577,15 @@ internal static class NexusDataExtractor
             }
         }
 
-        return new AuthorizeData(permissions, permissionEnumFqn, isUnderlyingTypeCompatible);
+        // Extract named arguments (e.g., CacheDurationSeconds)
+        int cacheDurationSeconds = -1;
+        foreach (var namedArg in attr.NamedArguments)
+        {
+            if (namedArg.Key == "CacheDurationSeconds" && namedArg.Value.Value is int cds)
+                cacheDurationSeconds = cds;
+        }
+
+        return new AuthorizeData(permissions, permissionEnumFqn, isUnderlyingTypeCompatible, cacheDurationSeconds);
     }
 
     private static NexusMethodAttributeData ExtractMethodAttribute(IMethodSymbol symbol)

--- a/src/NexNet.Generator/Extraction/NexusDataExtractor.cs
+++ b/src/NexNet.Generator/Extraction/NexusDataExtractor.cs
@@ -550,6 +550,15 @@ internal static class NexusDataExtractor
         var permissionType = attr.AttributeClass.TypeArguments[0];
         var permissionEnumFqn = permissionType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
 
+        // Check underlying type is compatible with int (long/ulong can overflow)
+        var isUnderlyingTypeCompatible = true;
+        if (permissionType is INamedTypeSymbol namedPermType && namedPermType.EnumUnderlyingType != null)
+        {
+            var underlying = namedPermType.EnumUnderlyingType.SpecialType;
+            if (underlying is SpecialType.System_Int64 or SpecialType.System_UInt64)
+                isUnderlyingTypeCompatible = false;
+        }
+
         // Extract constructor arguments (the params TPermission[] permissions)
         var permissions = ImmutableArray<int>.Empty;
         if (attr.ConstructorArguments.Length > 0)
@@ -568,7 +577,7 @@ internal static class NexusDataExtractor
             }
         }
 
-        return new AuthorizeData(permissions, permissionEnumFqn);
+        return new AuthorizeData(permissions, permissionEnumFqn, isUnderlyingTypeCompatible);
     }
 
     private static NexusMethodAttributeData ExtractMethodAttribute(IMethodSymbol symbol)

--- a/src/NexNet.Generator/Models/AuthorizeData.cs
+++ b/src/NexNet.Generator/Models/AuthorizeData.cs
@@ -1,0 +1,31 @@
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace NexNet.Generator.Models;
+
+/// <summary>
+/// Data for a [NexusAuthorize] attribute on a method.
+/// </summary>
+internal sealed record AuthorizeData(
+    ImmutableArray<int> Permissions,
+    string PermissionEnumFullyQualifiedName)
+{
+    public bool Equals(AuthorizeData? other)
+    {
+        if (other is null) return false;
+        if (ReferenceEquals(this, other)) return true;
+        return PermissionEnumFullyQualifiedName == other.PermissionEnumFullyQualifiedName
+               && Permissions.SequenceEqual(other.Permissions);
+    }
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hash = PermissionEnumFullyQualifiedName.GetHashCode();
+            foreach (var p in Permissions)
+                hash = hash * 31 + p;
+            return hash;
+        }
+    }
+}

--- a/src/NexNet.Generator/Models/AuthorizeData.cs
+++ b/src/NexNet.Generator/Models/AuthorizeData.cs
@@ -8,13 +8,15 @@ namespace NexNet.Generator.Models;
 /// </summary>
 internal sealed record AuthorizeData(
     ImmutableArray<int> Permissions,
-    string PermissionEnumFullyQualifiedName)
+    string PermissionEnumFullyQualifiedName,
+    bool IsUnderlyingTypeCompatible = true)
 {
     public bool Equals(AuthorizeData? other)
     {
         if (other is null) return false;
         if (ReferenceEquals(this, other)) return true;
         return PermissionEnumFullyQualifiedName == other.PermissionEnumFullyQualifiedName
+               && IsUnderlyingTypeCompatible == other.IsUnderlyingTypeCompatible
                && Permissions.SequenceEqual(other.Permissions);
     }
 
@@ -23,6 +25,7 @@ internal sealed record AuthorizeData(
         unchecked
         {
             var hash = PermissionEnumFullyQualifiedName.GetHashCode();
+            hash = hash * 31 + IsUnderlyingTypeCompatible.GetHashCode();
             foreach (var p in Permissions)
                 hash = hash * 31 + p;
             return hash;

--- a/src/NexNet.Generator/Models/AuthorizeData.cs
+++ b/src/NexNet.Generator/Models/AuthorizeData.cs
@@ -9,7 +9,8 @@ namespace NexNet.Generator.Models;
 internal sealed record AuthorizeData(
     ImmutableArray<int> Permissions,
     string PermissionEnumFullyQualifiedName,
-    bool IsUnderlyingTypeCompatible = true)
+    bool IsUnderlyingTypeCompatible = true,
+    int CacheDurationSeconds = -1)
 {
     public bool Equals(AuthorizeData? other)
     {
@@ -17,6 +18,7 @@ internal sealed record AuthorizeData(
         if (ReferenceEquals(this, other)) return true;
         return PermissionEnumFullyQualifiedName == other.PermissionEnumFullyQualifiedName
                && IsUnderlyingTypeCompatible == other.IsUnderlyingTypeCompatible
+               && CacheDurationSeconds == other.CacheDurationSeconds
                && Permissions.SequenceEqual(other.Permissions);
     }
 
@@ -26,6 +28,7 @@ internal sealed record AuthorizeData(
         {
             var hash = PermissionEnumFullyQualifiedName.GetHashCode();
             hash = hash * 31 + IsUnderlyingTypeCompatible.GetHashCode();
+            hash = hash * 31 + CacheDurationSeconds;
             foreach (var p in Permissions)
                 hash = hash * 31 + p;
             return hash;

--- a/src/NexNet.Generator/Models/CollectionData.cs
+++ b/src/NexNet.Generator/Models/CollectionData.cs
@@ -22,6 +22,7 @@ internal sealed record CollectionData(
     CollectionTypeValue CollectionType,
     NexusCollectionAttributeData CollectionAttribute,
     NexusMethodAttributeData? MethodAttribute,
+    AuthorizeData? AuthorizeData,
     LocationData? Location
 )
 {

--- a/src/NexNet.Generator/Models/MethodData.cs
+++ b/src/NexNet.Generator/Models/MethodData.cs
@@ -39,6 +39,9 @@ internal sealed record MethodData(
     // Attribute data
     NexusMethodAttributeData MethodAttribute,
 
+    // Authorization
+    AuthorizeData? AuthorizeData,
+
     // For diagnostics
     LocationData? Location
 )

--- a/src/NexNet.Generator/Validation/NexusValidator.cs
+++ b/src/NexNet.Generator/Validation/NexusValidator.cs
@@ -379,6 +379,22 @@ internal static class NexusValidator
                 data.TypeName));
         }
 
+        // Enum underlying type must fit in int
+        foreach (var method in authorizedMethods.Where(m => !m.AuthorizeData!.IsUnderlyingTypeCompatible))
+        {
+            diagnostics.Add(CreateDiagnostic(
+                DiagnosticDescriptors.AuthorizeEnumUnderlyingTypeIncompatible,
+                method.Location ?? data.IdentifierLocation,
+                method.Name));
+        }
+        foreach (var collection in authorizedCollections.Where(c => !c.AuthorizeData!.IsUnderlyingTypeCompatible))
+        {
+            diagnostics.Add(CreateDiagnostic(
+                DiagnosticDescriptors.AuthorizeEnumUnderlyingTypeIncompatible,
+                collection.Location ?? data.IdentifierLocation,
+                collection.Name));
+        }
+
         // Mixed permission enum types — collect from both methods and collections
         var enumTypes = authorizedMethods
             .Select(m => m.AuthorizeData!.PermissionEnumFullyQualifiedName)

--- a/src/NexNet.IntegrationTests/NexusServerTests_Authorization.cs
+++ b/src/NexNet.IntegrationTests/NexusServerTests_Authorization.cs
@@ -1,0 +1,401 @@
+using System.Net;
+using NexNet.Asp;
+using NexNet.Asp.HttpSocket;
+using NexNet.Asp.WebSocket;
+using NexNet.IntegrationTests.TestInterfaces;
+using NexNet.Invocation;
+using NexNet.Transports;
+using NexNet.Transports.HttpSocket;
+using NexNet.Transports.WebSocket;
+using NUnit.Framework;
+#pragma warning disable VSTHRD200
+
+namespace NexNet.IntegrationTests;
+
+internal class NexusServerTests_Authorization : BaseTests
+{
+    private readonly List<WebApplication> _aspApps = new();
+    private readonly List<INexusServerFactory> _authServerFactories = new();
+    private readonly List<INexusClient> _authClients = new();
+
+    public override void TearDown()
+    {
+        foreach (var client in _authClients)
+        {
+            if (client.State == ConnectionState.Connected)
+                _ = client.DisconnectAsync();
+        }
+        _authClients.Clear();
+
+        foreach (var sf in _authServerFactories)
+        {
+            if (sf.ServerBase.State == NexusServerState.Running)
+                _ = sf.ServerBase.StopAsync();
+        }
+        _authServerFactories.Clear();
+
+        foreach (var app in _aspApps)
+        {
+            try { app.Lifetime.StopApplication(); } catch { }
+        }
+        _aspApps.Clear();
+
+        base.TearDown();
+    }
+
+    private (NexusServerFactory<AuthServerNexus, AuthServerNexus.ClientProxy> server,
+        NexusClient<AuthClientNexus, AuthClientNexus.ServerProxy> client,
+        AuthClientNexus clientNexus)
+        CreateAuthServerClient(Type type)
+    {
+        var sConfig = CreateServerConfig(type);
+        var cConfig = CreateClientConfig(type);
+        var serverFactory = new NexusServerFactory<AuthServerNexus, AuthServerNexus.ClientProxy>(sConfig);
+        var clientNexus = new AuthClientNexus();
+        var client = AuthClientNexus.CreateClient(cConfig, clientNexus);
+        _authServerFactories.Add(serverFactory);
+        _authClients.Add(client);
+
+        if (sConfig is WebSocketServerConfig or HttpSocketServerConfig)
+        {
+            CurrentTcpPort ??= FreeTcpPort();
+            var builder = WebApplication.CreateBuilder();
+            builder.Logging.ClearProviders();
+            builder.WebHost.ConfigureKestrel((_, serverOptions) =>
+                serverOptions.Listen(IPAddress.Loopback, CurrentTcpPort.Value));
+            builder.Services.AddNexusServer<AuthServerNexus, AuthServerNexus.ClientProxy>();
+            var app = builder.Build();
+
+            if (sConfig is WebSocketServerConfig wsConfig)
+            {
+                app.UseWebSockets();
+                app.MapWebSocketNexus(wsConfig, serverFactory.Server);
+            }
+            else if (sConfig is HttpSocketServerConfig hsConfig)
+            {
+                app.UseHttpSockets();
+                app.MapHttpSocketNexus(hsConfig, serverFactory.Server);
+            }
+
+            _ = app.RunAsync();
+            _aspApps.Add(app);
+        }
+
+        return (serverFactory, client, clientNexus);
+    }
+
+
+    [TestCase(Type.Uds)]
+    [TestCase(Type.Tcp)]
+    [TestCase(Type.TcpTls)]
+    [TestCase(Type.Quic)]
+    [TestCase(Type.WebSocket)]
+    [TestCase(Type.HttpSocket)]
+    public async Task AuthorizedMethod_Allowed_InvokesMethod(Type type)
+    {
+        var methodInvoked = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var (server, client, _) = CreateAuthServerClient(type);
+
+        server.OnNexusCreated = nexus =>
+        {
+            nexus.OnAuthorizeHandler = (_, _, _, _) => new ValueTask<AuthorizeResult>(AuthorizeResult.Allowed);
+            nexus.ProtectedMethodHandler = (_, _) =>
+            {
+                methodInvoked.SetResult();
+                return ValueTask.CompletedTask;
+            };
+        };
+
+        await server.StartAsync().Timeout(1);
+        await client.ConnectAsync().Timeout(1);
+
+        await client.Proxy.ProtectedMethod("test").Timeout(1);
+        await methodInvoked.Task.Timeout(1);
+    }
+
+    [TestCase(Type.Uds)]
+    [TestCase(Type.Tcp)]
+    [TestCase(Type.TcpTls)]
+    [TestCase(Type.Quic)]
+    [TestCase(Type.WebSocket)]
+    [TestCase(Type.HttpSocket)]
+    public async Task AuthorizedMethod_Unauthorized_ThrowsOnClient(Type type)
+    {
+        var (server, client, _) = CreateAuthServerClient(type);
+
+        server.OnNexusCreated = nexus =>
+        {
+            nexus.OnAuthorizeHandler = (_, _, _, _) => new ValueTask<AuthorizeResult>(AuthorizeResult.Unauthorized);
+        };
+
+        await server.StartAsync().Timeout(1);
+        await client.ConnectAsync().Timeout(1);
+
+        Assert.ThrowsAsync<ProxyUnauthorizedException>(async () =>
+            await client.Proxy.ProtectedMethod("test").Timeout(1));
+    }
+
+    [TestCase(Type.Uds)]
+    [TestCase(Type.Tcp)]
+    [TestCase(Type.TcpTls)]
+    [TestCase(Type.Quic)]
+    [TestCase(Type.WebSocket)]
+    [TestCase(Type.HttpSocket)]
+    public async Task AuthorizedMethod_Disconnect_DisconnectsSession(Type type)
+    {
+        var disconnected = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var (server, client, clientNexus) = CreateAuthServerClient(type);
+
+        server.OnNexusCreated = nexus =>
+        {
+            nexus.OnAuthorizeHandler = (_, _, _, _) => new ValueTask<AuthorizeResult>(AuthorizeResult.Disconnect);
+        };
+
+        _ = client.DisconnectedTask.ContinueWith(_ => disconnected.TrySetResult());
+
+        await server.StartAsync().Timeout(1);
+        await client.ConnectAsync().Timeout(1);
+
+        // The invocation will fail since the session gets disconnected
+        try
+        {
+            await client.Proxy.ProtectedMethod("test").Timeout(1);
+        }
+        catch
+        {
+            // Expected - session disconnected
+        }
+
+        await disconnected.Task.Timeout(2);
+    }
+
+    [TestCase(Type.Uds)]
+    [TestCase(Type.Tcp)]
+    [TestCase(Type.TcpTls)]
+    [TestCase(Type.Quic)]
+    [TestCase(Type.WebSocket)]
+    [TestCase(Type.HttpSocket)]
+    public async Task UnprotectedMethod_NoAuthCheck(Type type)
+    {
+        var authCalled = false;
+        var methodInvoked = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var (server, client, _) = CreateAuthServerClient(type);
+
+        server.OnNexusCreated = nexus =>
+        {
+            nexus.OnAuthorizeHandler = (_, _, _, _) =>
+            {
+                authCalled = true;
+                return new ValueTask<AuthorizeResult>(AuthorizeResult.Unauthorized);
+            };
+            nexus.UnprotectedMethodHandler = _ =>
+            {
+                methodInvoked.SetResult();
+                return ValueTask.CompletedTask;
+            };
+        };
+
+        await server.StartAsync().Timeout(1);
+        await client.ConnectAsync().Timeout(1);
+
+        await client.Proxy.UnprotectedMethod().Timeout(1);
+        await methodInvoked.Task.Timeout(1);
+        Assert.That(authCalled, Is.False);
+    }
+
+    [TestCase(Type.Uds)]
+    [TestCase(Type.Tcp)]
+    [TestCase(Type.TcpTls)]
+    [TestCase(Type.Quic)]
+    [TestCase(Type.WebSocket)]
+    [TestCase(Type.HttpSocket)]
+    public async Task MarkerOnly_CallsOnAuthorizeWithEmptyPermissions(Type type)
+    {
+        ReadOnlyMemory<int> capturedPermissions = default;
+        var authCalled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var (server, client, _) = CreateAuthServerClient(type);
+
+        server.OnNexusCreated = nexus =>
+        {
+            nexus.OnAuthorizeHandler = (_, _, _, perms) =>
+            {
+                capturedPermissions = perms;
+                authCalled.SetResult();
+                return new ValueTask<AuthorizeResult>(AuthorizeResult.Allowed);
+            };
+            nexus.MarkerOnlyMethodHandler = _ => ValueTask.CompletedTask;
+        };
+
+        await server.StartAsync().Timeout(1);
+        await client.ConnectAsync().Timeout(1);
+
+        await client.Proxy.MarkerOnlyMethod().Timeout(1);
+        await authCalled.Task.Timeout(1);
+        Assert.That(capturedPermissions.Length, Is.EqualTo(0));
+    }
+
+    [TestCase(Type.Uds)]
+    [TestCase(Type.Tcp)]
+    [TestCase(Type.TcpTls)]
+    [TestCase(Type.Quic)]
+    [TestCase(Type.WebSocket)]
+    [TestCase(Type.HttpSocket)]
+    public async Task OnAuthorize_ReceivesCorrectMethodName(Type type)
+    {
+        string? capturedName = null;
+        var authCalled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var (server, client, _) = CreateAuthServerClient(type);
+
+        server.OnNexusCreated = nexus =>
+        {
+            nexus.OnAuthorizeHandler = (_, _, name, _) =>
+            {
+                capturedName = name;
+                authCalled.SetResult();
+                return new ValueTask<AuthorizeResult>(AuthorizeResult.Allowed);
+            };
+            nexus.ProtectedMethodHandler = (_, _) => ValueTask.CompletedTask;
+        };
+
+        await server.StartAsync().Timeout(1);
+        await client.ConnectAsync().Timeout(1);
+
+        await client.Proxy.ProtectedMethod("test").Timeout(1);
+        await authCalled.Task.Timeout(1);
+        Assert.That(capturedName, Is.EqualTo("ProtectedMethod"));
+    }
+
+    [TestCase(Type.Uds)]
+    [TestCase(Type.Tcp)]
+    [TestCase(Type.TcpTls)]
+    [TestCase(Type.Quic)]
+    [TestCase(Type.WebSocket)]
+    [TestCase(Type.HttpSocket)]
+    public async Task OnAuthorize_ReceivesCorrectPermissions(Type type)
+    {
+        ReadOnlyMemory<int> capturedPermissions = default;
+        var authCalled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var (server, client, _) = CreateAuthServerClient(type);
+
+        server.OnNexusCreated = nexus =>
+        {
+            nexus.OnAuthorizeHandler = (_, _, _, perms) =>
+            {
+                capturedPermissions = perms;
+                authCalled.SetResult();
+                return new ValueTask<AuthorizeResult>(AuthorizeResult.Allowed);
+            };
+            nexus.ProtectedMethodHandler = (_, _) => ValueTask.CompletedTask;
+        };
+
+        await server.StartAsync().Timeout(1);
+        await client.ConnectAsync().Timeout(1);
+
+        await client.Proxy.ProtectedMethod("test").Timeout(1);
+        await authCalled.Task.Timeout(1);
+        Assert.That(capturedPermissions.Length, Is.EqualTo(1));
+        Assert.That(capturedPermissions.Span[0], Is.EqualTo((int)TestPermission.Write));
+    }
+
+    [TestCase(Type.Uds)]
+    [TestCase(Type.Tcp)]
+    [TestCase(Type.TcpTls)]
+    [TestCase(Type.Quic)]
+    [TestCase(Type.WebSocket)]
+    [TestCase(Type.HttpSocket)]
+    public async Task Authorized_WithReturnValue_ReturnsResult(Type type)
+    {
+        var (server, client, _) = CreateAuthServerClient(type);
+
+        server.OnNexusCreated = nexus =>
+        {
+            nexus.OnAuthorizeHandler = (_, _, _, _) => new ValueTask<AuthorizeResult>(AuthorizeResult.Allowed);
+            nexus.ProtectedWithReturnHandler = (_, v) => new ValueTask<int>(v * 2);
+        };
+
+        await server.StartAsync().Timeout(1);
+        await client.ConnectAsync().Timeout(1);
+
+        var result = await client.Proxy.ProtectedWithReturn(21).Timeout(1);
+        Assert.That(result, Is.EqualTo(42));
+    }
+
+    [TestCase(Type.Uds)]
+    [TestCase(Type.Tcp)]
+    [TestCase(Type.TcpTls)]
+    [TestCase(Type.Quic)]
+    [TestCase(Type.WebSocket)]
+    [TestCase(Type.HttpSocket)]
+    public async Task Unauthorized_WithReturnValue_ThrowsNotReturns(Type type)
+    {
+        var (server, client, _) = CreateAuthServerClient(type);
+
+        server.OnNexusCreated = nexus =>
+        {
+            nexus.OnAuthorizeHandler = (_, _, _, _) => new ValueTask<AuthorizeResult>(AuthorizeResult.Unauthorized);
+        };
+
+        await server.StartAsync().Timeout(1);
+        await client.ConnectAsync().Timeout(1);
+
+        Assert.ThrowsAsync<ProxyUnauthorizedException>(async () =>
+            await client.Proxy.ProtectedWithReturn(21).Timeout(1));
+    }
+
+    [TestCase(Type.Uds)]
+    [TestCase(Type.Tcp)]
+    [TestCase(Type.TcpTls)]
+    [TestCase(Type.Quic)]
+    [TestCase(Type.WebSocket)]
+    [TestCase(Type.HttpSocket)]
+    public async Task Unauthorized_MethodBodyNeverExecutes(Type type)
+    {
+        var bodyExecuted = false;
+        var (server, client, _) = CreateAuthServerClient(type);
+
+        server.OnNexusCreated = nexus =>
+        {
+            nexus.OnAuthorizeHandler = (_, _, _, _) => new ValueTask<AuthorizeResult>(AuthorizeResult.Unauthorized);
+            nexus.ProtectedMethodHandler = (_, _) =>
+            {
+                bodyExecuted = true;
+                return ValueTask.CompletedTask;
+            };
+        };
+
+        await server.StartAsync().Timeout(1);
+        await client.ConnectAsync().Timeout(1);
+
+        try { await client.Proxy.ProtectedMethod("test").Timeout(1); } catch { }
+
+        // Small delay to ensure any async work settles
+        await Task.Delay(100);
+        Assert.That(bodyExecuted, Is.False);
+    }
+
+    [TestCase(Type.Uds)]
+    [TestCase(Type.Tcp)]
+    [TestCase(Type.TcpTls)]
+    [TestCase(Type.Quic)]
+    [TestCase(Type.WebSocket)]
+    [TestCase(Type.HttpSocket)]
+    public async Task OnAuthorize_ThrowsException_TreatedAsDisconnect(Type type)
+    {
+        var disconnected = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var (server, client, _) = CreateAuthServerClient(type);
+
+        server.OnNexusCreated = nexus =>
+        {
+            nexus.OnAuthorizeHandler = (_, _, _, _) => throw new InvalidOperationException("Auth error");
+        };
+
+        _ = client.DisconnectedTask.ContinueWith(_ => disconnected.TrySetResult());
+
+        await server.StartAsync().Timeout(1);
+        await client.ConnectAsync().Timeout(1);
+
+        try { await client.Proxy.ProtectedMethod("test").Timeout(1); } catch { }
+
+        await disconnected.Task.Timeout(2);
+    }
+}

--- a/src/NexNet.IntegrationTests/NexusServerTests_Authorization.cs
+++ b/src/NexNet.IntegrationTests/NexusServerTests_Authorization.cs
@@ -305,6 +305,39 @@ internal class NexusServerTests_Authorization : BaseTests
     [TestCase(Type.Quic)]
     [TestCase(Type.WebSocket)]
     [TestCase(Type.HttpSocket)]
+    public async Task OnAuthorize_ReceivesMultiplePermissions(Type type)
+    {
+        ReadOnlyMemory<int> capturedPermissions = default;
+        var authCalled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var (server, client, _) = CreateAuthServerClient(type);
+
+        server.OnNexusCreated = nexus =>
+        {
+            nexus.OnAuthorizeHandler = (_, _, _, perms) =>
+            {
+                capturedPermissions = perms;
+                authCalled.SetResult();
+                return new ValueTask<AuthorizeResult>(AuthorizeResult.Allowed);
+            };
+            nexus.MultiPermissionMethodHandler = (_, _) => ValueTask.CompletedTask;
+        };
+
+        await server.StartAsync().Timeout(1);
+        await client.ConnectAsync().Timeout(1);
+
+        await client.Proxy.MultiPermissionMethod("test").Timeout(1);
+        await authCalled.Task.Timeout(1);
+        Assert.That(capturedPermissions.Length, Is.EqualTo(2));
+        Assert.That(capturedPermissions.Span[0], Is.EqualTo((int)TestPermission.Read));
+        Assert.That(capturedPermissions.Span[1], Is.EqualTo((int)TestPermission.Admin));
+    }
+
+    [TestCase(Type.Uds)]
+    [TestCase(Type.Tcp)]
+    [TestCase(Type.TcpTls)]
+    [TestCase(Type.Quic)]
+    [TestCase(Type.WebSocket)]
+    [TestCase(Type.HttpSocket)]
     public async Task Authorized_WithReturnValue_ReturnsResult(Type type)
     {
         var (server, client, _) = CreateAuthServerClient(type);

--- a/src/NexNet.IntegrationTests/NexusServerTests_Authorization.cs
+++ b/src/NexNet.IntegrationTests/NexusServerTests_Authorization.cs
@@ -867,4 +867,47 @@ internal class NexusServerTests_Authorization : BaseTests
         // Session disconnected due to exception — auth was called once
         Assert.That(authCallCount, Is.EqualTo(1));
     }
+
+    [TestCase(Type.Uds)]
+    public async Task AuthCache_ConcurrentAccess_NoExceptions(Type type)
+    {
+        var authCallCount = 0;
+        var allThreadsReady = new ManualResetEventSlim(false);
+        var (server, client, _) = CreateAuthServerClient(type);
+
+        server.OnNexusCreated = nexus =>
+        {
+            nexus.OnAuthorizeHandler = (_, _, _, _) =>
+            {
+                Interlocked.Increment(ref authCallCount);
+                // Force all threads to pile up inside OnAuthorize simultaneously
+                allThreadsReady.Wait(TimeSpan.FromSeconds(2));
+                return new ValueTask<AuthorizeResult>(AuthorizeResult.Allowed);
+            };
+            nexus.CachedMethodHandler = _ => ValueTask.CompletedTask;
+        };
+
+        await server.StartAsync().Timeout(1);
+        await client.ConnectAsync().Timeout(1);
+
+        const int concurrentCalls = 10;
+        var tasks = new Task[concurrentCalls];
+        for (int i = 0; i < concurrentCalls; i++)
+        {
+            tasks[i] = Task.Run(async () =>
+            {
+                try { await client.Proxy.CachedMethod().Timeout(5); } catch { }
+            });
+        }
+
+        // Let all threads proceed once they've piled up
+        await Task.Delay(200);
+        allThreadsReady.Set();
+
+        await Task.WhenAll(tasks).WaitAsync(TimeSpan.FromSeconds(5));
+
+        // All calls should have completed without exceptions.
+        // Auth may be called multiple times (cache misses race) but never throws.
+        Assert.That(authCallCount, Is.GreaterThan(0));
+    }
 }

--- a/src/NexNet.IntegrationTests/NexusServerTests_Authorization.cs
+++ b/src/NexNet.IntegrationTests/NexusServerTests_Authorization.cs
@@ -48,9 +48,11 @@ internal class NexusServerTests_Authorization : BaseTests
     private (NexusServerFactory<AuthServerNexus, AuthServerNexus.ClientProxy> server,
         NexusClient<AuthClientNexus, AuthClientNexus.ServerProxy> client,
         AuthClientNexus clientNexus)
-        CreateAuthServerClient(Type type)
+        CreateAuthServerClient(Type type, TimeSpan? authCacheDuration = null)
     {
         var sConfig = CreateServerConfig(type);
+        if (authCacheDuration.HasValue)
+            sConfig.AuthorizationCacheDuration = authCacheDuration.Value;
         var cConfig = CreateClientConfig(type);
         var serverFactory = new NexusServerFactory<AuthServerNexus, AuthServerNexus.ClientProxy>(sConfig);
         var clientNexus = new AuthClientNexus();
@@ -526,5 +528,343 @@ internal class NexusServerTests_Authorization : BaseTests
         try { await client.Proxy.ProtectedMethod("test").Timeout(1); } catch { }
 
         await disconnected.Task.Timeout(2);
+    }
+
+    // --- Authorization cache tests ---
+    // Use Uds only since caching is transport-independent
+
+    [TestCase(Type.Uds)]
+    public async Task AuthCache_AttributeTtl_SecondCallUsesCachedResult(Type type)
+    {
+        var authCallCount = 0;
+        var (server, client, _) = CreateAuthServerClient(type);
+
+        server.OnNexusCreated = nexus =>
+        {
+            nexus.OnAuthorizeHandler = (_, _, _, _) =>
+            {
+                Interlocked.Increment(ref authCallCount);
+                return new ValueTask<AuthorizeResult>(AuthorizeResult.Allowed);
+            };
+            nexus.CachedMethodHandler = _ => ValueTask.CompletedTask;
+        };
+
+        await server.StartAsync().Timeout(1);
+        await client.ConnectAsync().Timeout(1);
+
+        await client.Proxy.CachedMethod().Timeout(1);
+        await client.Proxy.CachedMethod().Timeout(1);
+        await client.Proxy.CachedMethod().Timeout(1);
+
+        Assert.That(authCallCount, Is.EqualTo(1));
+    }
+
+    [TestCase(Type.Uds)]
+    public async Task AuthCache_AttributeTtl_ExpiredEntry_ReChecks(Type type)
+    {
+        var authCallCount = 0;
+        var currentTick = Environment.TickCount64;
+        var (server, client, _) = CreateAuthServerClient(type);
+
+        server.OnNexusCreated = nexus =>
+        {
+            nexus.TickCountOverride = () => Interlocked.Read(ref currentTick);
+            nexus.OnAuthorizeHandler = (_, _, _, _) =>
+            {
+                Interlocked.Increment(ref authCallCount);
+                return new ValueTask<AuthorizeResult>(AuthorizeResult.Allowed);
+            };
+            nexus.CachedMethodHandler = _ => ValueTask.CompletedTask;
+        };
+
+        await server.StartAsync().Timeout(1);
+        await client.ConnectAsync().Timeout(1);
+
+        await client.Proxy.CachedMethod().Timeout(1);
+        Assert.That(authCallCount, Is.EqualTo(1));
+
+        // Still cached
+        await client.Proxy.CachedMethod().Timeout(1);
+        Assert.That(authCallCount, Is.EqualTo(1));
+
+        // Advance past the 2s TTL
+        Interlocked.Add(ref currentTick, 2001);
+
+        await client.Proxy.CachedMethod().Timeout(1);
+        Assert.That(authCallCount, Is.EqualTo(2));
+    }
+
+    [TestCase(Type.Uds)]
+    public async Task AuthCache_NeverCached_AlwaysCallsOnAuthorize(Type type)
+    {
+        var authCallCount = 0;
+        // Set server-level cache to prove CacheDurationSeconds=0 overrides it
+        var (server, client, _) = CreateAuthServerClient(type, TimeSpan.FromSeconds(60));
+
+        server.OnNexusCreated = nexus =>
+        {
+            nexus.OnAuthorizeHandler = (_, _, _, _) =>
+            {
+                Interlocked.Increment(ref authCallCount);
+                return new ValueTask<AuthorizeResult>(AuthorizeResult.Allowed);
+            };
+            nexus.NeverCachedMethodHandler = _ => ValueTask.CompletedTask;
+        };
+
+        await server.StartAsync().Timeout(1);
+        await client.ConnectAsync().Timeout(1);
+
+        await client.Proxy.NeverCachedMethod().Timeout(1);
+        await client.Proxy.NeverCachedMethod().Timeout(1);
+        await client.Proxy.NeverCachedMethod().Timeout(1);
+
+        Assert.That(authCallCount, Is.EqualTo(3));
+    }
+
+    [TestCase(Type.Uds)]
+    public async Task AuthCache_ServerConfigDefault_CachesWhenAttributeIsDefault(Type type)
+    {
+        var authCallCount = 0;
+        // ProtectedMethod has no CacheDurationSeconds (defaults to -1), so server config applies
+        var (server, client, _) = CreateAuthServerClient(type, TimeSpan.FromSeconds(30));
+
+        server.OnNexusCreated = nexus =>
+        {
+            nexus.OnAuthorizeHandler = (_, _, _, _) =>
+            {
+                Interlocked.Increment(ref authCallCount);
+                return new ValueTask<AuthorizeResult>(AuthorizeResult.Allowed);
+            };
+            nexus.ProtectedMethodHandler = (_, _) => ValueTask.CompletedTask;
+        };
+
+        await server.StartAsync().Timeout(1);
+        await client.ConnectAsync().Timeout(1);
+
+        await client.Proxy.ProtectedMethod("a").Timeout(1);
+        await client.Proxy.ProtectedMethod("b").Timeout(1);
+        await client.Proxy.ProtectedMethod("c").Timeout(1);
+
+        Assert.That(authCallCount, Is.EqualTo(1));
+    }
+
+    [TestCase(Type.Uds)]
+    public async Task AuthCache_NoServerConfig_NoCaching(Type type)
+    {
+        var authCallCount = 0;
+        // No server config cache, ProtectedMethod has no CacheDurationSeconds override
+        var (server, client, _) = CreateAuthServerClient(type);
+
+        server.OnNexusCreated = nexus =>
+        {
+            nexus.OnAuthorizeHandler = (_, _, _, _) =>
+            {
+                Interlocked.Increment(ref authCallCount);
+                return new ValueTask<AuthorizeResult>(AuthorizeResult.Allowed);
+            };
+            nexus.ProtectedMethodHandler = (_, _) => ValueTask.CompletedTask;
+        };
+
+        await server.StartAsync().Timeout(1);
+        await client.ConnectAsync().Timeout(1);
+
+        await client.Proxy.ProtectedMethod("a").Timeout(1);
+        await client.Proxy.ProtectedMethod("b").Timeout(1);
+
+        Assert.That(authCallCount, Is.EqualTo(2));
+    }
+
+    [TestCase(Type.Uds)]
+    public async Task AuthCache_CachesUnauthorizedResult(Type type)
+    {
+        var authCallCount = 0;
+        var (server, client, _) = CreateAuthServerClient(type);
+
+        server.OnNexusCreated = nexus =>
+        {
+            nexus.OnAuthorizeHandler = (_, _, _, _) =>
+            {
+                Interlocked.Increment(ref authCallCount);
+                return new ValueTask<AuthorizeResult>(AuthorizeResult.Unauthorized);
+            };
+            nexus.CachedMethodHandler = _ => ValueTask.CompletedTask;
+        };
+
+        await server.StartAsync().Timeout(1);
+        await client.ConnectAsync().Timeout(1);
+
+        // CachedMethod has return type ValueTask (void), so Unauthorized with no return channel
+        // means silent drop. Just verify OnAuthorize is called once.
+        try { await client.Proxy.CachedMethod().Timeout(1); } catch { }
+        try { await client.Proxy.CachedMethod().Timeout(1); } catch { }
+
+        Assert.That(authCallCount, Is.EqualTo(1));
+    }
+
+    [TestCase(Type.Uds)]
+    public async Task AuthCache_DisconnectNeverCached(Type type)
+    {
+        var authCallCount = 0;
+        var disconnected = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var (server, client, _) = CreateAuthServerClient(type);
+
+        server.OnNexusCreated = nexus =>
+        {
+            nexus.OnAuthorizeHandler = (_, _, _, _) =>
+            {
+                Interlocked.Increment(ref authCallCount);
+                return new ValueTask<AuthorizeResult>(AuthorizeResult.Disconnect);
+            };
+            nexus.CachedMethodHandler = _ => ValueTask.CompletedTask;
+        };
+
+        _ = client.DisconnectedTask.ContinueWith(_ => disconnected.TrySetResult());
+
+        await server.StartAsync().Timeout(1);
+        await client.ConnectAsync().Timeout(1);
+
+        try { await client.Proxy.CachedMethod().Timeout(1); } catch { }
+
+        await disconnected.Task.Timeout(2);
+        // Disconnect result should not be cached (session dies anyway)
+        Assert.That(authCallCount, Is.EqualTo(1));
+    }
+
+    [TestCase(Type.Uds)]
+    public async Task AuthCache_DifferentMethodsHaveIndependentEntries(Type type)
+    {
+        var protectedCallCount = 0;
+        var cachedCallCount = 0;
+        var (server, client, _) = CreateAuthServerClient(type, TimeSpan.FromSeconds(30));
+
+        server.OnNexusCreated = nexus =>
+        {
+            nexus.OnAuthorizeHandler = (_, methodId, _, _) =>
+            {
+                // Track per-method auth calls by checking which method was invoked
+                // ProtectedMethod and CachedMethod will have different method IDs
+                return new ValueTask<AuthorizeResult>(AuthorizeResult.Allowed);
+            };
+            nexus.ProtectedMethodHandler = (_, _) =>
+            {
+                Interlocked.Increment(ref protectedCallCount);
+                return ValueTask.CompletedTask;
+            };
+            nexus.CachedMethodHandler = _ =>
+            {
+                Interlocked.Increment(ref cachedCallCount);
+                return ValueTask.CompletedTask;
+            };
+        };
+
+        await server.StartAsync().Timeout(1);
+        await client.ConnectAsync().Timeout(1);
+
+        await client.Proxy.ProtectedMethod("a").Timeout(1);
+        await client.Proxy.CachedMethod().Timeout(1);
+        await client.Proxy.ProtectedMethod("b").Timeout(1);
+        await client.Proxy.CachedMethod().Timeout(1);
+
+        // Both methods should have been invoked twice (cache is per-method)
+        Assert.That(protectedCallCount, Is.EqualTo(2));
+        Assert.That(cachedCallCount, Is.EqualTo(2));
+    }
+
+    [TestCase(Type.Uds)]
+    public async Task AuthCache_InvalidateAll_ClearsCache(Type type)
+    {
+        var authCallCount = 0;
+        var (server, client, _) = CreateAuthServerClient(type);
+
+        server.OnNexusCreated = nexus =>
+        {
+            nexus.OnAuthorizeHandler = (_, _, _, _) =>
+            {
+                Interlocked.Increment(ref authCallCount);
+                return new ValueTask<AuthorizeResult>(AuthorizeResult.Allowed);
+            };
+            nexus.CachedMethodHandler = _ => ValueTask.CompletedTask;
+        };
+
+        await server.StartAsync().Timeout(1);
+        await client.ConnectAsync().Timeout(1);
+
+        await client.Proxy.CachedMethod().Timeout(1);
+        Assert.That(authCallCount, Is.EqualTo(1));
+
+        // Invalidate cache
+        var serverNexus = server.NexusCreatedQueue.First();
+        serverNexus.CallInvalidateAll();
+
+        await client.Proxy.CachedMethod().Timeout(1);
+        Assert.That(authCallCount, Is.EqualTo(2));
+    }
+
+    [TestCase(Type.Uds)]
+    public async Task AuthCache_InvalidateByMethodId_ClearsSingleEntry(Type type)
+    {
+        var authCallCount = 0;
+        int cachedMethodId = -1;
+        var (server, client, _) = CreateAuthServerClient(type, TimeSpan.FromSeconds(30));
+
+        server.OnNexusCreated = nexus =>
+        {
+            nexus.OnAuthorizeHandler = (_, methodId, name, _) =>
+            {
+                Interlocked.Increment(ref authCallCount);
+                if (name == "CachedMethod")
+                    cachedMethodId = methodId;
+                return new ValueTask<AuthorizeResult>(AuthorizeResult.Allowed);
+            };
+            nexus.CachedMethodHandler = _ => ValueTask.CompletedTask;
+            nexus.ProtectedMethodHandler = (_, _) => ValueTask.CompletedTask;
+        };
+
+        await server.StartAsync().Timeout(1);
+        await client.ConnectAsync().Timeout(1);
+
+        // Prime both caches
+        await client.Proxy.CachedMethod().Timeout(1);
+        await client.Proxy.ProtectedMethod("a").Timeout(1);
+        Assert.That(authCallCount, Is.EqualTo(2));
+
+        // Invalidate only CachedMethod
+        var serverNexus = server.NexusCreatedQueue.First();
+        serverNexus.CallInvalidateMethod(cachedMethodId);
+
+        // CachedMethod should re-check, ProtectedMethod should still be cached
+        await client.Proxy.CachedMethod().Timeout(1);
+        await client.Proxy.ProtectedMethod("b").Timeout(1);
+        Assert.That(authCallCount, Is.EqualTo(3)); // Only CachedMethod re-checked
+    }
+
+    [TestCase(Type.Uds)]
+    public async Task AuthCache_ExceptionNotCached_NextCallReInvokes(Type type)
+    {
+        var authCallCount = 0;
+        var shouldThrow = true;
+        var (server, client, _) = CreateAuthServerClient(type);
+
+        server.OnNexusCreated = nexus =>
+        {
+            nexus.OnAuthorizeHandler = (_, _, _, _) =>
+            {
+                Interlocked.Increment(ref authCallCount);
+                if (shouldThrow)
+                    throw new InvalidOperationException("Auth error");
+                return new ValueTask<AuthorizeResult>(AuthorizeResult.Allowed);
+            };
+            nexus.CachedMethodHandler = _ => ValueTask.CompletedTask;
+        };
+
+        _ = client.DisconnectedTask.ContinueWith(_ => { });
+
+        await server.StartAsync().Timeout(1);
+        await client.ConnectAsync().Timeout(1);
+
+        try { await client.Proxy.CachedMethod().Timeout(1); } catch { }
+
+        // Session disconnected due to exception — auth was called once
+        Assert.That(authCallCount, Is.EqualTo(1));
     }
 }

--- a/src/NexNet.IntegrationTests/TestInterfaces/AuthorizationTestInterfaces.cs
+++ b/src/NexNet.IntegrationTests/TestInterfaces/AuthorizationTestInterfaces.cs
@@ -1,3 +1,5 @@
+using NexNet.Collections;
+using NexNet.Collections.Lists;
 using NexNet.Invocation;
 
 #pragma warning disable CS8618
@@ -14,6 +16,13 @@ public partial interface IAuthServerNexus
     ValueTask UnprotectedMethod();
     ValueTask MarkerOnlyMethod();
     ValueTask<int> ProtectedWithReturn(int value);
+
+    [NexusCollection(NexusCollectionMode.ServerToClient)]
+    [NexusAuthorize<TestPermission>(TestPermission.Read)]
+    INexusList<string> ProtectedList { get; }
+
+    [NexusCollection(NexusCollectionMode.ServerToClient)]
+    INexusList<string> UnprotectedList { get; }
 }
 
 public partial interface IAuthClientNexus { }

--- a/src/NexNet.IntegrationTests/TestInterfaces/AuthorizationTestInterfaces.cs
+++ b/src/NexNet.IntegrationTests/TestInterfaces/AuthorizationTestInterfaces.cs
@@ -1,0 +1,73 @@
+using NexNet.Invocation;
+
+#pragma warning disable CS8618
+#pragma warning disable VSTHRD200
+
+namespace NexNet.IntegrationTests.TestInterfaces;
+
+public enum TestPermission { Read, Write, Admin }
+
+public partial interface IAuthServerNexus
+{
+    ValueTask ProtectedMethod(string input);
+    ValueTask AdminMethod();
+    ValueTask UnprotectedMethod();
+    ValueTask MarkerOnlyMethod();
+    ValueTask<int> ProtectedWithReturn(int value);
+}
+
+public partial interface IAuthClientNexus { }
+
+[Nexus<IAuthServerNexus, IAuthClientNexus>(NexusType = NexusType.Server)]
+public partial class AuthServerNexus
+{
+    public Func<ServerSessionContext<AuthServerNexus.ClientProxy>, int, string, ReadOnlyMemory<int>, ValueTask<AuthorizeResult>>? OnAuthorizeHandler;
+
+    public Func<AuthServerNexus, string, ValueTask>? ProtectedMethodHandler;
+    public Func<AuthServerNexus, ValueTask>? AdminMethodHandler;
+    public Func<AuthServerNexus, ValueTask>? UnprotectedMethodHandler;
+    public Func<AuthServerNexus, ValueTask>? MarkerOnlyMethodHandler;
+    public Func<AuthServerNexus, int, ValueTask<int>>? ProtectedWithReturnHandler;
+
+    [NexusAuthorize<TestPermission>(TestPermission.Write)]
+    public ValueTask ProtectedMethod(string input)
+    {
+        return ProtectedMethodHandler?.Invoke(this, input) ?? ValueTask.CompletedTask;
+    }
+
+    [NexusAuthorize<TestPermission>(TestPermission.Admin)]
+    public ValueTask AdminMethod()
+    {
+        return AdminMethodHandler?.Invoke(this) ?? ValueTask.CompletedTask;
+    }
+
+    public ValueTask UnprotectedMethod()
+    {
+        return UnprotectedMethodHandler?.Invoke(this) ?? ValueTask.CompletedTask;
+    }
+
+    [NexusAuthorize<TestPermission>()]
+    public ValueTask MarkerOnlyMethod()
+    {
+        return MarkerOnlyMethodHandler?.Invoke(this) ?? ValueTask.CompletedTask;
+    }
+
+    [NexusAuthorize<TestPermission>(TestPermission.Read)]
+    public ValueTask<int> ProtectedWithReturn(int value)
+    {
+        return ProtectedWithReturnHandler?.Invoke(this, value) ?? new ValueTask<int>(0);
+    }
+
+    protected override ValueTask<AuthorizeResult> OnAuthorize(
+        ServerSessionContext<ClientProxy> context,
+        int methodId,
+        string methodName,
+        ReadOnlyMemory<int> requiredPermissions)
+    {
+        return OnAuthorizeHandler?.Invoke(context, methodId, methodName, requiredPermissions)
+               ?? new ValueTask<AuthorizeResult>(AuthorizeResult.Allowed);
+    }
+}
+
+[Nexus<IAuthClientNexus, IAuthServerNexus>(NexusType = NexusType.Client)]
+public partial class AuthClientNexus { }

--- a/src/NexNet.IntegrationTests/TestInterfaces/AuthorizationTestInterfaces.cs
+++ b/src/NexNet.IntegrationTests/TestInterfaces/AuthorizationTestInterfaces.cs
@@ -16,6 +16,7 @@ public partial interface IAuthServerNexus
     ValueTask UnprotectedMethod();
     ValueTask MarkerOnlyMethod();
     ValueTask<int> ProtectedWithReturn(int value);
+    ValueTask MultiPermissionMethod(string input);
 
     [NexusCollection(NexusCollectionMode.ServerToClient)]
     [NexusAuthorize<TestPermission>(TestPermission.Read)]
@@ -37,6 +38,7 @@ public partial class AuthServerNexus
     public Func<AuthServerNexus, ValueTask>? UnprotectedMethodHandler;
     public Func<AuthServerNexus, ValueTask>? MarkerOnlyMethodHandler;
     public Func<AuthServerNexus, int, ValueTask<int>>? ProtectedWithReturnHandler;
+    public Func<AuthServerNexus, string, ValueTask>? MultiPermissionMethodHandler;
 
     [NexusAuthorize<TestPermission>(TestPermission.Write)]
     public ValueTask ProtectedMethod(string input)
@@ -65,6 +67,12 @@ public partial class AuthServerNexus
     public ValueTask<int> ProtectedWithReturn(int value)
     {
         return ProtectedWithReturnHandler?.Invoke(this, value) ?? new ValueTask<int>(0);
+    }
+
+    [NexusAuthorize<TestPermission>(TestPermission.Read, TestPermission.Admin)]
+    public ValueTask MultiPermissionMethod(string input)
+    {
+        return MultiPermissionMethodHandler?.Invoke(this, input) ?? ValueTask.CompletedTask;
     }
 
     protected override ValueTask<AuthorizeResult> OnAuthorize(

--- a/src/NexNet.IntegrationTests/TestInterfaces/AuthorizationTestInterfaces.cs
+++ b/src/NexNet.IntegrationTests/TestInterfaces/AuthorizationTestInterfaces.cs
@@ -17,6 +17,8 @@ public partial interface IAuthServerNexus
     ValueTask MarkerOnlyMethod();
     ValueTask<int> ProtectedWithReturn(int value);
     ValueTask MultiPermissionMethod(string input);
+    ValueTask CachedMethod();
+    ValueTask NeverCachedMethod();
 
     [NexusCollection(NexusCollectionMode.ServerToClient)]
     [NexusAuthorize<TestPermission>(TestPermission.Read)]
@@ -39,6 +41,13 @@ public partial class AuthServerNexus
     public Func<AuthServerNexus, ValueTask>? MarkerOnlyMethodHandler;
     public Func<AuthServerNexus, int, ValueTask<int>>? ProtectedWithReturnHandler;
     public Func<AuthServerNexus, string, ValueTask>? MultiPermissionMethodHandler;
+    public Func<AuthServerNexus, ValueTask>? CachedMethodHandler;
+    public Func<AuthServerNexus, ValueTask>? NeverCachedMethodHandler;
+    public Action? InvalidateAllAction;
+    public Action<int>? InvalidateMethodAction;
+
+    public void CallInvalidateAll() => InvalidateAuthorizationCache();
+    public void CallInvalidateMethod(int methodId) => InvalidateAuthorizationCache(methodId);
 
     [NexusAuthorize<TestPermission>(TestPermission.Write)]
     public ValueTask ProtectedMethod(string input)
@@ -73,6 +82,18 @@ public partial class AuthServerNexus
     public ValueTask MultiPermissionMethod(string input)
     {
         return MultiPermissionMethodHandler?.Invoke(this, input) ?? ValueTask.CompletedTask;
+    }
+
+    [NexusAuthorize<TestPermission>(TestPermission.Read, CacheDurationSeconds = 2)]
+    public ValueTask CachedMethod()
+    {
+        return CachedMethodHandler?.Invoke(this) ?? ValueTask.CompletedTask;
+    }
+
+    [NexusAuthorize<TestPermission>(TestPermission.Read, CacheDurationSeconds = 0)]
+    public ValueTask NeverCachedMethod()
+    {
+        return NeverCachedMethodHandler?.Invoke(this) ?? ValueTask.CompletedTask;
     }
 
     protected override ValueTask<AuthorizeResult> OnAuthorize(

--- a/src/NexNet/AuthorizeResult.cs
+++ b/src/NexNet/AuthorizeResult.cs
@@ -1,0 +1,22 @@
+namespace NexNet;
+
+/// <summary>
+/// Result of an authorization check on a nexus method invocation.
+/// </summary>
+public enum AuthorizeResult
+{
+    /// <summary>
+    /// Invocation is allowed to proceed normally.
+    /// </summary>
+    Allowed,
+
+    /// <summary>
+    /// Invocation is unauthorized. Returns an error to the caller without invoking the method.
+    /// </summary>
+    Unauthorized,
+
+    /// <summary>
+    /// Invocation is unauthorized and the session should be immediately disconnected.
+    /// </summary>
+    Disconnect
+}

--- a/src/NexNet/Invocation/ProxyInvocationBase.cs
+++ b/src/NexNet/Invocation/ProxyInvocationBase.cs
@@ -227,6 +227,9 @@ public abstract class ProxyInvocationBase : IProxyInvoker
             case InvocationResultMessage.StateType.Exception:
                 throw new ProxyRemoteInvocationException();
 
+            case InvocationResultMessage.StateType.Unauthorized:
+                throw new ProxyUnauthorizedException();
+
             default:
                 throw new InvalidOperationException($"Unknown state {messageState}");
         }
@@ -263,6 +266,10 @@ public abstract class ProxyInvocationBase : IProxyInvoker
             case InvocationResultMessage.StateType.Exception:
                 ReturnState(state);
                 throw new ProxyRemoteInvocationException();
+
+            case InvocationResultMessage.StateType.Unauthorized:
+                ReturnState(state);
+                throw new ProxyUnauthorizedException();
 
             default:
                 ReturnState(state);

--- a/src/NexNet/Invocation/ProxyRemoteInvocationException.cs
+++ b/src/NexNet/Invocation/ProxyRemoteInvocationException.cs
@@ -14,6 +14,15 @@ public class ProxyRemoteInvocationException : Exception
     public ProxyRemoteInvocationException()
         : base("Exception occurred while executing method on proxy.")
     {
-        
+
+    }
+
+    /// <summary>
+    /// Constructs the exception with a custom message.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    protected ProxyRemoteInvocationException(string message)
+        : base(message)
+    {
     }
 }

--- a/src/NexNet/Invocation/ProxyUnauthorizedException.cs
+++ b/src/NexNet/Invocation/ProxyUnauthorizedException.cs
@@ -1,0 +1,15 @@
+namespace NexNet.Invocation;
+
+/// <summary>
+/// Exception thrown on the calling side when a method invocation is denied by the server's authorization check.
+/// </summary>
+public sealed class ProxyUnauthorizedException : ProxyRemoteInvocationException
+{
+    /// <summary>
+    /// Creates a new instance of <see cref="ProxyUnauthorizedException"/>.
+    /// </summary>
+    public ProxyUnauthorizedException()
+        : base("Method invocation was unauthorized by the server.")
+    {
+    }
+}

--- a/src/NexNet/Invocation/ServerNexusBase.cs
+++ b/src/NexNet/Invocation/ServerNexusBase.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using NexNet.Logging;
+using NexNet.Messages;
 
 namespace NexNet.Invocation;
 
@@ -42,5 +44,57 @@ public abstract class ServerNexusBase<TProxy> : NexusBase<TProxy>
     protected virtual ValueTask OnNexusInitialize()
     {
         return ValueTask.CompletedTask;
+    }
+
+    /// <summary>
+    /// Called by the generated auth guard before an authorized method is invoked.
+    /// Override to implement custom authorization logic.
+    /// </summary>
+    /// <param name="context">The server session context.</param>
+    /// <param name="methodId">The method ID being invoked.</param>
+    /// <param name="methodName">The name of the method being invoked.</param>
+    /// <param name="requiredPermissions">The required permission values (as ints) from the attribute. Empty if marker-only.</param>
+    /// <returns>The authorization result controlling invocation behavior.</returns>
+    protected virtual ValueTask<AuthorizeResult> OnAuthorize(
+        ServerSessionContext<TProxy> context,
+        int methodId,
+        string methodName,
+        ReadOnlyMemory<int> requiredPermissions)
+    {
+        return new ValueTask<AuthorizeResult>(AuthorizeResult.Allowed);
+    }
+
+    /// <summary>
+    /// Internal wrapper called by generated code to invoke OnAuthorize with the typed context.
+    /// </summary>
+    internal async ValueTask<AuthorizeResult> Authorize(
+        int methodId,
+        string methodName,
+        ReadOnlyMemory<int> requiredPermissions)
+    {
+        try
+        {
+            return await OnAuthorize(Context, methodId, methodName, requiredPermissions).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // Fail-safe: if OnAuthorize itself throws, treat as disconnect.
+            SessionContext.Session.Logger?.LogError(ex, $"OnAuthorize threw an exception for method '{methodName}' (id={methodId}). Disconnecting session.");
+            return AuthorizeResult.Disconnect;
+        }
+    }
+
+    /// <summary>
+    /// Sends an unauthorized invocation result back to the caller.
+    /// Called by generated auth guard code.
+    /// </summary>
+    internal async ValueTask SendUnauthorizedResult(ushort invocationId)
+    {
+        var message = SessionContext.PoolManager.Rent<InvocationResultMessage>();
+        message.InvocationId = invocationId;
+        message.Result = null;
+        message.State = InvocationResultMessage.StateType.Unauthorized;
+        await SessionContext.Session.SendMessage(message).ConfigureAwait(false);
+        message.Dispose();
     }
 }

--- a/src/NexNet/Invocation/ServerNexusBase.cs
+++ b/src/NexNet/Invocation/ServerNexusBase.cs
@@ -65,9 +65,9 @@ public abstract class ServerNexusBase<TProxy> : NexusBase<TProxy>
     }
 
     /// <summary>
-    /// Internal wrapper called by generated code to invoke OnAuthorize with the typed context.
+    /// Wrapper called by generated auth guard code to invoke OnAuthorize with the typed context.
     /// </summary>
-    internal async ValueTask<AuthorizeResult> Authorize(
+    protected async ValueTask<AuthorizeResult> Authorize(
         int methodId,
         string methodName,
         ReadOnlyMemory<int> requiredPermissions)
@@ -88,7 +88,7 @@ public abstract class ServerNexusBase<TProxy> : NexusBase<TProxy>
     /// Sends an unauthorized invocation result back to the caller.
     /// Called by generated auth guard code.
     /// </summary>
-    internal async ValueTask SendUnauthorizedResult(ushort invocationId)
+    protected async ValueTask SendUnauthorizedResult(ushort invocationId)
     {
         var message = SessionContext.PoolManager.Rent<InvocationResultMessage>();
         message.InvocationId = invocationId;

--- a/src/NexNet/Invocation/ServerNexusBase.cs
+++ b/src/NexNet/Invocation/ServerNexusBase.cs
@@ -1,8 +1,10 @@
-﻿using System;
+using System;
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using NexNet.Logging;
 using NexNet.Messages;
+using NexNet.Transports;
 
 namespace NexNet.Invocation;
 
@@ -13,6 +15,9 @@ namespace NexNet.Invocation;
 public abstract class ServerNexusBase<TProxy> : NexusBase<TProxy>
     where TProxy : ProxyInvocationBase, IProxyInvoker, new()
 {
+    private Dictionary<int, (AuthorizeResult Result, long ExpiresAtTicks)>? _authCache;
+    internal Func<long>? TickCountOverride;
+
     /// <summary>
     /// Context for this current session.
     /// </summary>
@@ -30,12 +35,12 @@ public abstract class ServerNexusBase<TProxy> : NexusBase<TProxy>
     {
         return ValueTask.FromResult((IIdentity?)null);
     }
-    
+
     internal ValueTask NexusInitialize()
     {
         return OnNexusInitialize();
     }
-    
+
     /// <summary>
     /// Initializes the nexus. Is performed after the session has invoked <see cref="OnAuthenticate"/> (if applicable), but prior to <see cref="NexusBase{TProxy}.OnConnected"/>.
     /// Good for registration of groups.  If an exception occurs on this method, the session will be disconnected.  Invoked on the same task as <see cref="OnAuthenticate"/>.
@@ -65,6 +70,23 @@ public abstract class ServerNexusBase<TProxy> : NexusBase<TProxy>
     }
 
     /// <summary>
+    /// Invalidates all cached authorization results for this session.
+    /// </summary>
+    protected void InvalidateAuthorizationCache()
+    {
+        _authCache?.Clear();
+    }
+
+    /// <summary>
+    /// Invalidates the cached authorization result for a specific method in this session.
+    /// </summary>
+    /// <param name="methodId">The method ID whose cached result should be removed.</param>
+    protected void InvalidateAuthorizationCache(int methodId)
+    {
+        _authCache?.Remove(methodId);
+    }
+
+    /// <summary>
     /// Called by generated auth guard code. Runs the authorization check and handles
     /// Unauthorized (sends error result) and Disconnect (disconnects session) outcomes.
     /// Returns true if the method invocation should proceed, false otherwise.
@@ -74,14 +96,50 @@ public abstract class ServerNexusBase<TProxy> : NexusBase<TProxy>
     /// <param name="requiredPermissions">The required permission int values from the attribute.</param>
     /// <param name="invocationId">The invocation ID for sending result messages.</param>
     /// <param name="hasReturnChannel">Whether the caller expects a return value (returnBuffer != null).</param>
+    /// <param name="cacheDurationSeconds">Per-method cache override: -1 = use server config, 0 = no cache, &gt;0 = seconds.</param>
     /// <returns>True if authorized and the method should proceed; false if handled (unauthorized or disconnected).</returns>
     protected async ValueTask<bool> CheckAuthorization(
         int methodId,
         string methodName,
         ReadOnlyMemory<int> requiredPermissions,
         ushort invocationId,
-        bool hasReturnChannel)
+        bool hasReturnChannel,
+        int cacheDurationSeconds)
     {
+        // Resolve effective cache duration in milliseconds
+        long cacheDurationMs = 0;
+        if (cacheDurationSeconds > 0)
+        {
+            // Method/collection attribute override
+            cacheDurationMs = cacheDurationSeconds * 1000L;
+        }
+        else if (cacheDurationSeconds == -1)
+        {
+            // Fall back to server config
+            if (SessionContext.Session.Config is ServerConfig serverConfig
+                && serverConfig.AuthorizationCacheDuration is { } configDuration
+                && configDuration > TimeSpan.Zero)
+            {
+                cacheDurationMs = (long)configDuration.TotalMilliseconds;
+            }
+        }
+        // cacheDurationSeconds == 0 means explicitly no cache
+
+        // Check cache
+        if (cacheDurationMs > 0 && _authCache != null
+            && _authCache.TryGetValue(methodId, out var cached))
+        {
+            if ((TickCountOverride?.Invoke() ?? Environment.TickCount64) < cached.ExpiresAtTicks)
+            {
+                // Cache hit
+                return await HandleAuthResult(cached.Result, invocationId, hasReturnChannel)
+                    .ConfigureAwait(false);
+            }
+
+            // Expired
+            _authCache.Remove(methodId);
+        }
+
         AuthorizeResult result;
         try
         {
@@ -93,6 +151,21 @@ public abstract class ServerNexusBase<TProxy> : NexusBase<TProxy>
             result = AuthorizeResult.Disconnect;
         }
 
+        // Cache Allowed and Unauthorized results (never Disconnect or exceptions)
+        if (cacheDurationMs > 0 && result is AuthorizeResult.Allowed or AuthorizeResult.Unauthorized)
+        {
+            _authCache ??= new Dictionary<int, (AuthorizeResult, long)>();
+            _authCache[methodId] = (result, (TickCountOverride?.Invoke() ?? Environment.TickCount64) + cacheDurationMs);
+        }
+
+        return await HandleAuthResult(result, invocationId, hasReturnChannel).ConfigureAwait(false);
+    }
+
+    private async ValueTask<bool> HandleAuthResult(
+        AuthorizeResult result,
+        ushort invocationId,
+        bool hasReturnChannel)
+    {
         switch (result)
         {
             case AuthorizeResult.Allowed:

--- a/src/NexNet/Invocation/ServerNexusBase.cs
+++ b/src/NexNet/Invocation/ServerNexusBase.cs
@@ -106,11 +106,17 @@ public abstract class ServerNexusBase<TProxy> : NexusBase<TProxy>
                 if (hasReturnChannel)
                 {
                     var message = SessionContext.PoolManager.Rent<InvocationResultMessage>();
-                    message.InvocationId = invocationId;
-                    message.Result = null;
-                    message.State = InvocationResultMessage.StateType.Unauthorized;
-                    await SessionContext.Session.SendMessage(message).ConfigureAwait(false);
-                    message.Dispose();
+                    try
+                    {
+                        message.InvocationId = invocationId;
+                        message.Result = null;
+                        message.State = InvocationResultMessage.StateType.Unauthorized;
+                        await SessionContext.Session.SendMessage(message).ConfigureAwait(false);
+                    }
+                    finally
+                    {
+                        message.Dispose();
+                    }
                 }
                 return false;
 

--- a/src/NexNet/Invocation/ServerNexusBase.cs
+++ b/src/NexNet/Invocation/ServerNexusBase.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using NexNet.Logging;
@@ -15,7 +15,7 @@ namespace NexNet.Invocation;
 public abstract class ServerNexusBase<TProxy> : NexusBase<TProxy>
     where TProxy : ProxyInvocationBase, IProxyInvoker, new()
 {
-    private Dictionary<int, (AuthorizeResult Result, long ExpiresAtTicks)>? _authCache;
+    private ConcurrentDictionary<int, (AuthorizeResult Result, long ExpiresAtTicks)>? _authCache;
     internal Func<long>? TickCountOverride;
 
     /// <summary>
@@ -83,7 +83,7 @@ public abstract class ServerNexusBase<TProxy> : NexusBase<TProxy>
     /// <param name="methodId">The method ID whose cached result should be removed.</param>
     protected void InvalidateAuthorizationCache(int methodId)
     {
-        _authCache?.Remove(methodId);
+        _authCache?.TryRemove(methodId, out _);
     }
 
     /// <summary>
@@ -96,7 +96,7 @@ public abstract class ServerNexusBase<TProxy> : NexusBase<TProxy>
     /// <param name="requiredPermissions">The required permission int values from the attribute.</param>
     /// <param name="invocationId">The invocation ID for sending result messages.</param>
     /// <param name="hasReturnChannel">Whether the caller expects a return value (returnBuffer != null).</param>
-    /// <param name="cacheDurationSeconds">Per-method cache override: -1 = use server config, 0 = no cache, &gt;0 = seconds.</param>
+    /// <param name="cacheDurationSeconds">Per-method cache override: -1 = use server config, 0 = no cache, positive = seconds.</param>
     /// <returns>True if authorized and the method should proceed; false if handled (unauthorized or disconnected).</returns>
     protected async ValueTask<bool> CheckAuthorization(
         int methodId,
@@ -126,10 +126,11 @@ public abstract class ServerNexusBase<TProxy> : NexusBase<TProxy>
         // cacheDurationSeconds == 0 means explicitly no cache
 
         // Check cache
+        var now = TickCountOverride?.Invoke() ?? Environment.TickCount64;
         if (cacheDurationMs > 0 && _authCache != null
             && _authCache.TryGetValue(methodId, out var cached))
         {
-            if ((TickCountOverride?.Invoke() ?? Environment.TickCount64) < cached.ExpiresAtTicks)
+            if (now < cached.ExpiresAtTicks)
             {
                 // Cache hit
                 return await HandleAuthResult(cached.Result, invocationId, hasReturnChannel)
@@ -137,7 +138,7 @@ public abstract class ServerNexusBase<TProxy> : NexusBase<TProxy>
             }
 
             // Expired
-            _authCache.Remove(methodId);
+            _authCache.TryRemove(methodId, out _);
         }
 
         AuthorizeResult result;
@@ -154,7 +155,7 @@ public abstract class ServerNexusBase<TProxy> : NexusBase<TProxy>
         // Cache Allowed and Unauthorized results (never Disconnect or exceptions)
         if (cacheDurationMs > 0 && result is AuthorizeResult.Allowed or AuthorizeResult.Unauthorized)
         {
-            _authCache ??= new Dictionary<int, (AuthorizeResult, long)>();
+            _authCache ??= new ConcurrentDictionary<int, (AuthorizeResult, long)>();
             _authCache[methodId] = (result, (TickCountOverride?.Invoke() ?? Environment.TickCount64) + cacheDurationMs);
         }
 

--- a/src/NexNet/Messages/DisconnectReason.cs
+++ b/src/NexNet/Messages/DisconnectReason.cs
@@ -69,4 +69,9 @@ public enum DisconnectReason : byte
     /// Connection was rejected due to rate limiting.
     /// </summary>
     RateLimited = MessageType.DisconnectRateLimited,
+
+    /// <summary>
+    /// Connection was disconnected due to an unauthorized method invocation.
+    /// </summary>
+    Unauthorized = MessageType.DisconnectUnauthorized,
 }

--- a/src/NexNet/Messages/InvocationResultMessage.cs
+++ b/src/NexNet/Messages/InvocationResultMessage.cs
@@ -12,7 +12,8 @@ internal partial class InvocationResultMessage : IMessageBase
     {
         Unset = 0,
         CompletedResult = 1,
-        Exception = 2
+        Exception = 2,
+        Unauthorized = 3
     }
 
     public static MessageType Type { get; } = MessageType.InvocationResult;

--- a/src/NexNet/Messages/MessageType.cs
+++ b/src/NexNet/Messages/MessageType.cs
@@ -79,6 +79,11 @@ public enum MessageType : byte
     /// </summary>
     DisconnectRateLimited = 33,
 
+    /// <summary>
+    /// Connection was disconnected due to an unauthorized method invocation. No body.
+    /// </summary>
+    DisconnectUnauthorized = 34,
+
     // Reserved through -39
 
     /// <summary>

--- a/src/NexNet/Messages/MessageType.cs
+++ b/src/NexNet/Messages/MessageType.cs
@@ -84,7 +84,7 @@ public enum MessageType : byte
     /// </summary>
     DisconnectUnauthorized = 34,
 
-    // Reserved through -39
+    // Reserved through 39
 
     /// <summary>
     /// Header for data sent to a pipe.

--- a/src/NexNet/NexusAuthorizeAttribute.cs
+++ b/src/NexNet/NexusAuthorizeAttribute.cs
@@ -7,7 +7,7 @@ namespace NexNet;
 /// that calls <c>OnAuthorize</c> before the method body executes.
 /// </summary>
 /// <typeparam name="TPermission">Enum type representing the permission set.</typeparam>
-[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, AllowMultiple = false)]
 public class NexusAuthorizeAttribute<TPermission> : Attribute
     where TPermission : struct, Enum
 {

--- a/src/NexNet/NexusAuthorizeAttribute.cs
+++ b/src/NexNet/NexusAuthorizeAttribute.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace NexNet;
+
+/// <summary>
+/// Marks a server nexus method as requiring authorization. The generator emits an auth guard
+/// that calls <c>OnAuthorize</c> before the method body executes.
+/// </summary>
+/// <typeparam name="TPermission">Enum type representing the permission set.</typeparam>
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+public class NexusAuthorizeAttribute<TPermission> : Attribute
+    where TPermission : struct, Enum
+{
+    /// <summary>
+    /// The permissions required to invoke this method.
+    /// An empty array means "requires auth, no specific permission."
+    /// </summary>
+    public TPermission[] Permissions { get; }
+
+    /// <summary>
+    /// Marks the method as requiring authorization with the specified permissions.
+    /// </summary>
+    /// <param name="permissions">Zero or more permissions required.</param>
+    public NexusAuthorizeAttribute(params TPermission[] permissions)
+    {
+        Permissions = permissions;
+    }
+}

--- a/src/NexNet/NexusAuthorizeAttribute.cs
+++ b/src/NexNet/NexusAuthorizeAttribute.cs
@@ -18,6 +18,14 @@ public class NexusAuthorizeAttribute<TPermission> : Attribute
     public TPermission[] Permissions { get; }
 
     /// <summary>
+    /// Controls authorization result caching for this method/collection.
+    /// -1 (default) = use server config <c>AuthorizationCacheDuration</c>.
+    ///  0 = never cache (always call <c>OnAuthorize</c>).
+    /// &gt;0 = cache for this many seconds (overrides server config).
+    /// </summary>
+    public int CacheDurationSeconds { get; set; } = -1;
+
+    /// <summary>
     /// Marks the method as requiring authorization with the specified permissions.
     /// </summary>
     /// <param name="permissions">Zero or more permissions required.</param>

--- a/src/NexNet/Transports/ServerConfig.cs
+++ b/src/NexNet/Transports/ServerConfig.cs
@@ -36,6 +36,13 @@ public abstract class ServerConfig : ConfigBase
     public ConnectionRateLimitConfig? RateLimiting { get; set; }
 
     /// <summary>
+    /// Default duration for caching authorization results per session.
+    /// Null (default) = caching disabled. Positive values enable caching for that duration.
+    /// Can be overridden per-method/collection via <c>NexusAuthorizeAttribute.CacheDurationSeconds</c>.
+    /// </summary>
+    public TimeSpan? AuthorizationCacheDuration { get; set; }
+
+    /// <summary>
     /// Creates the listener and starts.
     /// </summary>
     /// <param name="cancellationToken"></param>


### PR DESCRIPTION
## Summary

Adds `[NexusAuthorize<TPermission>]` attribute support for authorization on server nexus methods and synchronized collections. The source generator emits auth guards in `InvokeMethodCore` that call a virtual `OnAuthorize` method before any argument deserialization or method/collection execution. Users define a permission enum, decorate server nexus methods or collection properties with `[NexusAuthorize<TPermission>(...)]`, and override `OnAuthorize` for custom authorization logic.

**Method example:**
```csharp
[NexusAuthorize<Permission>(Permission.Admin)]
public override ValueTask AdminMethod() { ... }

protected override ValueTask<AuthorizeResult> OnAuthorize(
    ServerSessionContext<TProxy> context, int methodId,
    string methodName, ReadOnlyMemory<int> requiredPermissions)
{
    // Custom auth logic
}
```

**Collection example:**
```csharp
public partial interface IServerNexus
{
    [NexusCollection(NexusCollectionMode.ServerToClient)]
    [NexusAuthorize<Permission>(Permission.Admin)]
    INexusList<string> SecureItems { get; }
}
```

Collection authorization is enforced on every connect/reconnect since all collection connections go through `InvokeMethodCore`. Reconnecting clients are re-authorized automatically.

### Authorization result caching

Authorization results can be cached per-session with configurable TTL at two levels:

```csharp
// Server-wide default (null = disabled)
serverConfig.AuthorizationCacheDuration = TimeSpan.FromSeconds(30);

// Per-method/collection override (-1 = use server config, 0 = never cache, >0 = seconds)
[NexusAuthorize<Permission>(Permission.Read, CacheDurationSeconds = 60)]  // 60s override
[NexusAuthorize<Permission>(Permission.Admin, CacheDurationSeconds = 0)]  // never cache
[NexusAuthorize<Permission>(Permission.Write)]                             // use server default
```

| Method attribute | Server config | Result |
|---|---|---|
| not set (-1) | null | no caching |
| not set (-1) | 30s | 30s |
| 0 | 30s | no caching (explicit disable) |
| 60 | 30s | 60s (method wins) |
| 10 | null | 10s (method wins even without server default) |

Only `Allowed` and `Unauthorized` results are cached. `Disconnect` and exception paths are never cached. Cache is per-nexus instance (per session) and invalidated automatically on reconnection. Explicit invalidation is available via `InvalidateAuthorizationCache()`.

## Reason for the change

NexNet had no built-in authorization mechanism. Users needing per-method or per-collection access control had to implement manual checks, which is error-prone, repetitive, and happens after argument deserialization (wasted work for unauthorized calls). This feature provides a declarative, generator-driven approach with compile-time type safety for both methods and collections.

## Impacts of changes

- **New public types:** `AuthorizeResult` enum, `NexusAuthorizeAttribute<TPermission>`, `ProxyUnauthorizedException`
- **Modified attribute:** `NexusAuthorizeAttribute` now targets `Method | Property` (was `Method` only), gains `CacheDurationSeconds` property
- **Modified base class:** `ServerNexusBase<TProxy>` gains `OnAuthorize` virtual, `CheckAuthorization` protected method, `InvalidateAuthorizationCache()` overloads, and per-session auth cache
- **Modified config:** `ServerConfig` gains `AuthorizationCacheDuration` property
- **Wire protocol:** New `InvocationResultMessage.StateType.Unauthorized` (value 3), new `MessageType.DisconnectUnauthorized` (value 34), new `DisconnectReason.Unauthorized`
- **Generator:** Extracts `[NexusAuthorize<>]` from class methods and interface collection properties, emits static permission arrays and auth guards for both, adds 4 new diagnostics (NEXNET024-027) covering methods and collections
- **Generator models:** `CollectionData` gains `AuthorizeData?` field; `ExtractAuthorizeData` refactored to shared helper supporting both `IMethodSymbol` and `IPropertySymbol`
- **Proxy layer:** `ProxyInvocationBase` now handles `Unauthorized` state by throwing `ProxyUnauthorizedException`

## Migration Steps

None required. This is a purely additive feature. Existing code continues to work without modification. To adopt:

1. Define a permission enum backed by `int` (the default) -- non-`int` underlying types are rejected at compile time via NEXNET027
2. Add `[NexusAuthorize<TPermission>(...)]` to server nexus class methods and/or interface collection properties
3. Override `OnAuthorize` on the server nexus class
4. Catch `ProxyUnauthorizedException` on the client side where needed (methods only -- collections use `Disconnect` for unauthorized access since they lack a return channel)
5. Optionally configure `ServerConfig.AuthorizationCacheDuration` or per-method `CacheDurationSeconds` for caching

## Performance Considerations

- **Zero cost for unannotated methods/collections** -- no auth guard is emitted without `[NexusAuthorize]`
- **Auth check before deserialization** -- unauthorized calls skip argument deserialization entirely
- **Synchronous fast-path** -- `OnAuthorize` returning `ValueTask<AuthorizeResult>` with a synchronous result allocates nothing
- **Static permission arrays** -- `int[]` arrays are emitted as `static readonly` class fields, allocated once
- **AOT compatible** -- all permission values are resolved at compile time by the source generator; no reflection or runtime type inspection
- **Authorization caching** -- opt-in TTL-based caching avoids repeated `OnAuthorize` calls for hot paths; thread-safe `ConcurrentDictionary<int, ...>` per session keyed by method ID with lock-free reads

## Security Considerations

- **Fail-safe on exception:** If `OnAuthorize` throws, the session is disconnected (logged as error). This prevents accidental authorization bypass from buggy auth logic
- **Server-side only:** Authorization is enforced server-side; clients cannot bypass it. The attribute is a compile-time error on client nexuses (NEXNET024)
- **Per-invocation:** Auth is checked on every invocation (unless cached), not permanently cached. After reconnection, auth is re-evaluated naturally. Collection reconnections go through `InvokeMethodCore` and are re-authorized
- **Compile-time errors:** NEXNET025 errors if `[NexusAuthorize]` is used but `OnAuthorize` is not overridden (default allows all). Applies to both methods and collections
- **Enum type safety:** NEXNET027 errors if the permission enum is not backed by `int` (the default), since permission values are stored as `Int32`
- **Pool-safe unauthorized response:** `InvocationResultMessage` is disposed in a `try/finally` block to prevent pool leaks if `SendMessage` throws
- **Cache security:** Only `Allowed` and `Unauthorized` are cached; `Disconnect` and exception paths are never cached. Cache is per-session with explicit invalidation support. `CacheDurationSeconds = 0` provides an explicit no-cache override for sensitive methods
- **Collection auth note:** `AuthorizeResult.Unauthorized` on a collection silently drops the request since collections lack a return channel. Use `AuthorizeResult.Disconnect` to actively reject unauthorized collection access

## Diagnostics

| ID | Severity | Description |
|---|---|---|
| NEXNET024 | Error | `[NexusAuthorize]` used on a client nexus (server-only) |
| NEXNET025 | Error | `[NexusAuthorize]` used but `OnAuthorize` not overridden |
| NEXNET026 | Error | Mixed permission enum types across `[NexusAuthorize]` attributes |
| NEXNET027 | Error | Permission enum not backed by `int` (the default) |

## Breaking changes

### Public consumer-facing changes

None. All additions are backward-compatible:
- `AuthorizeResult`, `NexusAuthorizeAttribute<T>`, `ProxyUnauthorizedException` are new types
- `OnAuthorize` virtual has a default implementation returning `Allowed`
- `DisconnectReason.Unauthorized` is a new enum member (underlying byte value 34)
- `ServerConfig.AuthorizationCacheDuration` defaults to `null` (disabled)
- `NexusAuthorizeAttribute.CacheDurationSeconds` defaults to `-1` (use server config)

### Internal non-consumer changes

- `InvocationResultMessage.StateType` gains `Unauthorized = 3` -- older clients receiving this from a newer server will hit the `default` switch case and throw `InvalidOperationException`. This only occurs if the feature is actively used against an older client.
- `ProxyRemoteInvocationException` gains a `protected` constructor accepting a `string message` parameter (for `ProxyUnauthorizedException` inheritance). This is binary-compatible but a minor API surface addition.
- `MessageType.DisconnectUnauthorized = 34` -- older peers receiving this will not recognize the disconnect reason, but will still disconnect cleanly as the transport closes.

