### PR TITLE
Add AOT compatibility and sample projects

### DIFF
--- a/src/NexNet.Generator/Emission/MethodEmitter.cs
+++ b/src/NexNet.Generator/Emission/MethodEmitter.cs
@@ -265,6 +265,9 @@ internal static class MethodEmitter
             sb.Remove(sb.Length - 2, 2);
 
             sb.AppendLine(");");
+
+            // Serialize the arguments to bytes at the call site (AOT-safe: concrete type known at compile time).
+            sb.AppendLine("                 var __serializedArgs = global::MemoryPack.MemoryPackSerializer.Serialize(__proxyInvocationArguments);");
         }
 
         // Logging
@@ -298,7 +301,7 @@ internal static class MethodEmitter
             sb.Append(method.DuplexPipeParameter == null ? "_ = " : "return ");
 
             sb.Append("__proxyInvoker.ProxyInvokeMethodCore(").Append(method.Id).Append(", ");
-            sb.Append(method.SerializedParameterCount > 0 ? "__proxyInvocationArguments, " : "null, ");
+            sb.Append(method.SerializedParameterCount > 0 ? "__serializedArgs, " : "global::System.Memory<byte>.Empty, ");
 
             // If we have a duplex pipe parameter, we need to pass the duplex pipe invocation flag.
             sb.Append("global::NexNet.Messages.InvocationFlags.")
@@ -313,7 +316,7 @@ internal static class MethodEmitter
             }
 
             sb.Append("(").Append(method.Id).Append(", "); // methodId
-            sb.Append(method.SerializedParameterCount > 0 ? "__proxyInvocationArguments, " : "null, "); // arguments
+            sb.Append(method.SerializedParameterCount > 0 ? "__serializedArgs, " : "global::System.Memory<byte>.Empty, "); // arguments
             sb.Append(method.CancellationTokenParameter != null ? method.CancellationTokenParameter.Name : "null")
                 .AppendLine(");");
         }

--- a/src/NexNet.IntegrationTests/Collections/Lists/NexusListTests.cs
+++ b/src/NexNet.IntegrationTests/Collections/Lists/NexusListTests.cs
@@ -825,4 +825,35 @@ internal class NexusListTests : NexusCollectionBaseTests
 
         Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => client.Proxy.IntListBi.RemoveAtAsync(-1).Timeout(1));
     }
+
+    [TestCase(Type.Quic)]
+    [TestCase(Type.Uds)]
+    [TestCase(Type.Tcp)]
+    [TestCase(Type.TcpTls)]
+    [TestCase(Type.WebSocket)]
+    [TestCase(Type.HttpSocket)]
+    public async Task ClientEnableAfterServerAdds_NoDuplicateItems(Type type)
+    {
+        var (server, client, _) = await ConnectServerAndClient(type);
+        var serverNexus = server.NexusCreatedQueue.First();
+
+        // Add items on server BEFORE client enables collection sync.
+        // This creates a window where broadcast messages for these adds
+        // could overlap with the reset snapshot sent during EnableAsync.
+        await serverNexus.IntListBi.AddAsync(1).Timeout(1);
+        await serverNexus.IntListBi.AddAsync(2).Timeout(1);
+        await serverNexus.IntListBi.AddAsync(3).Timeout(1);
+
+        await client.Proxy.IntListBi.EnableAsync().Timeout(1);
+
+        // Perform a move to verify the client state has no duplicates.
+        await client.Proxy.IntListBi.MoveAsync(0, 2).Timeout(1);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(client.Proxy.IntListBi.Count, Is.EqualTo(3));
+            Assert.That(client.Proxy.IntListBi, Is.EquivalentTo(serverNexus.IntListBi));
+            Assert.That(client.Proxy.IntListBi, Is.EquivalentTo([2, 3, 1]));
+        });
+    }
 }

--- a/src/NexNet.IntegrationTests/SessionManagement/MockNexusSession.cs
+++ b/src/NexNet.IntegrationTests/SessionManagement/MockNexusSession.cs
@@ -107,7 +107,7 @@ internal class MockSessionInvocationStateManager : ISessionInvocationStateManage
 
     public ValueTask<RegisteredInvocationState?> InvokeMethodWithResultCore(
         ushort methodId,
-        ITuple? arguments,
+        Memory<byte> serializedArguments,
         INexusSession session,
         CancellationToken? cancellationToken = null)
     {

--- a/src/NexNet/Collections/Lists/NexusListClient.cs
+++ b/src/NexNet/Collections/Lists/NexusListClient.cs
@@ -99,7 +99,7 @@ internal class NexusListClient<T> : NexusBroadcastClient<INexusCollectionListMes
         }
         
         var (op, version) = NexusListTransformers<T>.RentOperation(message);
-        
+
         // Unknown operation
         if (op == null)
         {
@@ -107,8 +107,15 @@ internal class NexusListClient<T> : NexusBroadcastClient<INexusCollectionListMes
             return new BroadcastMessageProcessResult(false, true);
         }
 
+        // Discard stale operations already included in a reset snapshot.
+        if (version > 0 && version <= _itemList.Version)
+        {
+            op.Return();
+            return new BroadcastMessageProcessResult(true, false);
+        }
+
         var result = _itemList.ApplyOperation(op, version);
-        
+
         if (result != ListProcessResult.DiscardOperation && result != ListProcessResult.Successful)
         {
             Client?.Logger?.LogWarning($"Processing {message} message failed with {result}");

--- a/src/NexNet/Internals/Collections/Versioned/VersionedList.cs
+++ b/src/NexNet/Internals/Collections/Versioned/VersionedList.cs
@@ -127,9 +127,9 @@ internal class VersionedList<T> : IEquatable<T[]>, IReadOnlyList<T>
     {
         if (!ValidateOperation(op))
             return ListProcessResult.BadOperation;
-        
+
         op.Apply(ref State, version);
-        
+
         return ListProcessResult.Successful;
     }
 

--- a/src/NexNet/Internals/Pipelines/Helpers.cs
+++ b/src/NexNet/Internals/Pipelines/Helpers.cs
@@ -67,7 +67,7 @@ internal enum Counter
 internal static class Helpers
 {
 #if DEBUG
-    private readonly static int[] _counters = new int[Enum.GetValues(typeof(Counter)).Length];
+    private readonly static int[] _counters = new int[Enum.GetValues<Counter>().Length];
     internal static void ResetCounters()
     {
         Array.Clear(_counters, 0, _counters.Length);
@@ -75,7 +75,7 @@ internal static class Helpers
     }
     internal static string GetCounterSummary()
     {
-        var enums = (Counter[])Enum.GetValues(typeof(Counter));
+        var enums = Enum.GetValues<Counter>();
         var sb = new System.Text.StringBuilder();
         for(int i = 0 ; i < enums.Length ; i++)
         {

--- a/src/NexNet/Internals/Pipelines/SocketConnection.cs
+++ b/src/NexNet/Internals/Pipelines/SocketConnection.cs
@@ -6,7 +6,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.IO.Pipelines;
 using System.Net.Sockets;
-using System.Reflection;
+
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -249,47 +249,16 @@ internal sealed partial class SocketConnection : IMeasuredDuplexPipe, IDisposabl
     /// </summary>
     public readonly struct Counters
     {
-        private static readonly Func<Pipe, long> s_pipeLengthReader;
-        static Counters()
-        {
-            try
-            {
-                // theoretically there's a problem here on x86; I'm... "comfortable enough" with it
-                // not to try to do anything more clever, though - if an x86 client has gone over 2GiB
-                // then they deserve a clap - a slow clap
-                var method = typeof(Pipe).GetProperty("Length",
-                    BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)?.GetGetMethod(true);
-                if (method is null)
-                {
-                    s_pipeLengthReader = _ => 0L;
-                }
-                else
-                {
-                    s_pipeLengthReader = (Func<Pipe, long>)Delegate.CreateDelegate(typeof(Func<Pipe, long>), method);
-                }
-            }
-            catch (Exception ex)
-            {
-                Debug.WriteLine(ex.Message);
-                s_pipeLengthReader = _ => 0L;
-            }
-        }
+        [System.Runtime.CompilerServices.UnsafeAccessor(System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = "get_Length")]
+        private static extern long GetLength(Pipe pipe);
 
         /// <summary>
-        /// Get the number of bytes currently held in a pipe instance
+        /// Get the number of bytes currently held in a pipe instance.
         /// </summary>
         public static long GetPipeLength(Pipe pipe)
         {
             if (pipe is null) return 0;
-            try
-            {
-                return s_pipeLengthReader(pipe);
-            }
-            catch (Exception ex)
-            {
-                Debug.WriteLine(ex.Message);
-                return 0;
-            }
+            return GetLength(pipe);
         }
 
         /// <summary>

--- a/src/NexNet/Invocation/IProxyInvoker.cs
+++ b/src/NexNet/Invocation/IProxyInvoker.cs
@@ -27,7 +27,7 @@ public interface IProxyInvoker
         IServerSessionManager? sessionManager,
         ProxyInvocationMode mode,
         object? modeArguments);
-    
+
     /// <summary>
     /// Logger for the current session.
     /// </summary>
@@ -38,23 +38,23 @@ public interface IProxyInvoker
     /// Will not wait for results on invocations and will instruct the proxy to dismiss any results.
     /// </summary>
     /// <param name="methodId">Method ID to invoke.</param>
-    /// <param name="arguments">Optional arguments to pass to the method invocation.</param>
+    /// <param name="serializedArguments">Pre-serialized argument bytes.</param>
     /// <param name="flags">Special flags for the invocation of this method.</param>
     /// <returns>Task which returns when the invocations messages have been issued.</returns>
     /// <exception cref="ArgumentOutOfRangeException">Thrown if the invocation mode is set in an invalid mode.</exception>
-    ValueTask ProxyInvokeMethodCore(ushort methodId, ITuple? arguments, InvocationFlags flags);
+    ValueTask ProxyInvokeMethodCore(ushort methodId, Memory<byte> serializedArguments, InvocationFlags flags);
 
     /// <summary>
     /// Invokes a method ID on the connection with the optionally passed arguments and optional cancellation token
     /// and waits the completion of the invocation.
     /// </summary>
     /// <param name="methodId">Method ID to invoke.</param>
-    /// <param name="arguments">Optional arguments to pass to the method invocation</param>
+    /// <param name="serializedArguments">Pre-serialized argument bytes.</param>
     /// <param name="cancellationToken">Optional cancellation token to allow cancellation of remote invocation.</param>
     /// <returns>ValueTask which completes upon remote invocation completion.</returns>
     /// <exception cref="ProxyRemoteInvocationException">Throws this exception if the remote invocation threw an exception.</exception>
     /// <exception cref="InvalidOperationException">Invocation returned invalid state data upon completion.</exception>
-    ValueTask ProxyInvokeAndWaitForResultCore(ushort methodId, ITuple? arguments, CancellationToken? cancellationToken = null);
+    ValueTask ProxyInvokeAndWaitForResultCore(ushort methodId, Memory<byte> serializedArguments, CancellationToken? cancellationToken = null);
 
     /// <summary>
     /// Invokes a method ID on the connection with the optionally passed arguments and optional cancellation token,
@@ -62,12 +62,12 @@ public interface IProxyInvoker
     /// </summary>
     /// <typeparam name="TReturn">Expected type to be returned by the remote invocation proxy.</typeparam>
     /// <param name="methodId">Method ID to invoke.</param>
-    /// <param name="arguments">Optional arguments to pass to the method invocation</param>
+    /// <param name="serializedArguments">Pre-serialized argument bytes.</param>
     /// <param name="cancellationToken">Optional cancellation token to allow cancellation of remote invocation.</param>
     /// <returns>ValueTask with the containing return result which completes upon remote invocation completion.</returns>
     /// <exception cref="ProxyRemoteInvocationException">Throws this exception if the remote invocation threw an exception.</exception>
     /// <exception cref="InvalidOperationException">Invocation returned invalid state data upon completion.</exception>
-    ValueTask<TReturn> ProxyInvokeAndWaitForResultCore<TReturn>(ushort methodId, ITuple? arguments, CancellationToken? cancellationToken = null);
+    ValueTask<TReturn> ProxyInvokeAndWaitForResultCore<TReturn>(ushort methodId, Memory<byte> serializedArguments, CancellationToken? cancellationToken = null);
 
     /// <summary>
     /// Gets the Initial Id of the duplex pipe.
@@ -78,10 +78,10 @@ public interface IProxyInvoker
 
 
     /// <summary>
-    /// Provides client side access to a configured list. 
+    /// Provides client side access to a configured list.
     /// </summary>
     /// <param name="id">
-    ///     A unique identifier for the list collection to configure.  
+    ///     A unique identifier for the list collection to configure.
     ///     This must match the identifier used when retrieving or starting the collection.
     /// </param>
     /// <typeparam name="T">The element type stored in the list.</typeparam>

--- a/src/NexNet/Invocation/ISessionInvocationStateManager.cs
+++ b/src/NexNet/Invocation/ISessionInvocationStateManager.cs
@@ -1,4 +1,4 @@
-using System.Runtime.CompilerServices;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using NexNet.Internals;
@@ -31,13 +31,13 @@ internal interface ISessionInvocationStateManager
     /// Invokes a method and waits for the result.
     /// </summary>
     /// <param name="methodId">The method ID to invoke.</param>
-    /// <param name="arguments">Optional arguments to pass to the method.</param>
+    /// <param name="serializedArguments">Pre-serialized argument bytes.</param>
     /// <param name="session">The session to invoke on.</param>
     /// <param name="cancellationToken">Optional cancellation token.</param>
     /// <returns>The registered invocation state, or null if cancelled.</returns>
     ValueTask<RegisteredInvocationState?> InvokeMethodWithResultCore(
         ushort methodId,
-        ITuple? arguments,
+        Memory<byte> serializedArguments,
         INexusSession session,
         CancellationToken? cancellationToken = null);
 

--- a/src/NexNet/Invocation/ProxyInvocationBase.cs
+++ b/src/NexNet/Invocation/ProxyInvocationBase.cs
@@ -95,19 +95,19 @@ public abstract class ProxyInvocationBase : IProxyInvoker
     }
 
     /// <inheritdoc />
-    async ValueTask IProxyInvoker.ProxyInvokeMethodCore(ushort methodId, ITuple? arguments, InvocationFlags flags)
+    async ValueTask IProxyInvoker.ProxyInvokeMethodCore(ushort methodId, Memory<byte> serializedArguments, InvocationFlags flags)
     {
         // Verify if we are on the server or client.  Server will use the _sessionManager and the client will use _session.
         if (_sessionManager == null && _session?.State != ConnectionState.Connected)
             throw new InvalidOperationException("Session is not connected");
-        
+
         var message = _poolManager.Rent<InvocationMessage>();
         message.MethodId = methodId;
         message.Flags = InvocationFlags.IgnoreReturn | flags;
         message.InvocationId = 0;
 
         // Try to set the arguments. If we can not, then the arguments are too large.
-        if (!message.TrySetArguments(arguments))
+        if (!message.TrySetArguments(serializedArguments))
         {
             message.Dispose();
             throw new ArgumentOutOfRangeException($"Message arguments exceeds maximum size allowed Must be {IInvocationMessage.MaxArgumentSize} bytes or less.");
@@ -205,13 +205,13 @@ public abstract class ProxyInvocationBase : IProxyInvoker
     }
 
     /// <inheritdoc />
-    async ValueTask IProxyInvoker.ProxyInvokeAndWaitForResultCore(ushort methodId, ITuple? arguments, CancellationToken? cancellationToken)
+    async ValueTask IProxyInvoker.ProxyInvokeAndWaitForResultCore(ushort methodId, Memory<byte> serializedArguments, CancellationToken? cancellationToken)
     {
         // Verify if we are on the server or client.  Server will use the _sessionManager and the client will use _session.
         if (_sessionManager == null && _session?.State != ConnectionState.Connected)
             throw new InvalidOperationException("Session is not connected");
-        
-        var state = await InvokeWaitForResultCore(methodId, arguments, cancellationToken).ConfigureAwait(false);
+
+        var state = await InvokeWaitForResultCore(methodId, serializedArguments, cancellationToken).ConfigureAwait(false);
 
         if (state == null)
             return;
@@ -236,13 +236,13 @@ public abstract class ProxyInvocationBase : IProxyInvoker
     }
 
     /// <inheritdoc />
-    async ValueTask<TReturn> IProxyInvoker.ProxyInvokeAndWaitForResultCore<TReturn>(ushort methodId, ITuple? arguments, CancellationToken? cancellationToken)
+    async ValueTask<TReturn> IProxyInvoker.ProxyInvokeAndWaitForResultCore<TReturn>(ushort methodId, Memory<byte> serializedArguments, CancellationToken? cancellationToken)
     {
         // Verify if we are on the server or client.  Server will use the _sessionManager and the client will use _session.
         if (_sessionManager == null && _session?.State != ConnectionState.Connected)
             throw new InvalidOperationException("Session is not connected");
-        
-        var state = await InvokeWaitForResultCore(methodId, arguments, cancellationToken).ConfigureAwait(false);
+
+        var state = await InvokeWaitForResultCore(methodId, serializedArguments, cancellationToken).ConfigureAwait(false);
 
         if (state == null)
         {
@@ -327,7 +327,7 @@ public abstract class ProxyInvocationBase : IProxyInvoker
 
     private async ValueTask<RegisteredInvocationState?> InvokeWaitForResultCore(
         ushort methodId,
-        ITuple? arguments,
+        Memory<byte> serializedArguments,
         CancellationToken? cancellationToken = null)
     {
         // If we are invoking on multiple sessions, then we are not going to wait
@@ -340,7 +340,7 @@ public abstract class ProxyInvocationBase : IProxyInvoker
             || _mode == ProxyInvocationMode.Others)
         {
             await Unsafe.As<IProxyInvoker>(this)
-                .ProxyInvokeMethodCore(methodId, arguments, InvocationFlags.None)
+                .ProxyInvokeMethodCore(methodId, serializedArguments, InvocationFlags.None)
                 .ConfigureAwait(false);
             return null;
         }
@@ -363,8 +363,8 @@ public abstract class ProxyInvocationBase : IProxyInvoker
 
         var state = await session.SessionInvocationStateManager.InvokeMethodWithResultCore(
             methodId,
-            arguments, 
-            session, 
+            serializedArguments,
+            session,
             cancellationToken).ConfigureAwait(false);
 
         if (state == null)

--- a/src/NexNet/Invocation/SessionInvocationStateManager.cs
+++ b/src/NexNet/Invocation/SessionInvocationStateManager.cs
@@ -109,7 +109,7 @@ internal class SessionInvocationStateManager : ISessionInvocationStateManager
 
     public async ValueTask<RegisteredInvocationState?> InvokeMethodWithResultCore(
         ushort methodId,
-        ITuple? arguments,
+        Memory<byte> serializedArguments,
         INexusSession session,
         CancellationToken? cancellationToken = null)
     {
@@ -123,7 +123,7 @@ internal class SessionInvocationStateManager : ISessionInvocationStateManager
         message.Flags = InvocationFlags.None;
 
         // Try to set the arguments. If we can not, then the arguments are too large.
-        if (!message.TrySetArguments(arguments))
+        if (!message.TrySetArguments(serializedArguments))
         {
             throw new ArgumentOutOfRangeException($"Message arguments exceeds maximum size allowed Must be {IInvocationMessage.MaxArgumentSize} bytes or less.");
         }

--- a/src/NexNet/Messages/IInvocationMessage.cs
+++ b/src/NexNet/Messages/IInvocationMessage.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 namespace NexNet.Messages;
@@ -43,5 +44,5 @@ public interface IInvocationMessage
     /// <typeparam name="T">Type to deserialize to.</typeparam>
     /// <returns>Deserialized value</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    T? DeserializeArguments<T>();
+    T? DeserializeArguments<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>();
 }

--- a/src/NexNet/Messages/InvocationMessage.cs
+++ b/src/NexNet/Messages/InvocationMessage.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using MemoryPack;
@@ -40,39 +41,22 @@ internal partial class InvocationMessage : IMessageBase, IInvocationMessage
     public Memory<byte> Arguments { get; set; }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public T? DeserializeArguments<T>()
+    public T? DeserializeArguments<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>()
     {
         return MemoryPackSerializer.Deserialize<T>(Arguments.Span);
     }
-    public bool TrySetArguments(ITuple? arguments)
-    {
-        Arguments = arguments == null
-            ? Memory<byte>.Empty
-            : MemoryPackSerializer.Serialize(arguments.GetType(), arguments);
 
-        //TODO: Review this on the sync path as it will get ignored as it is running on a separate task from the original caller.
+    /// <summary>
+    /// Sets the pre-serialized argument bytes on this message.
+    /// </summary>
+    /// <param name="serializedArguments">Pre-serialized argument bytes.</param>
+    /// <returns>True if the arguments fit within the maximum size.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool TrySetArguments(Memory<byte> serializedArguments)
+    {
+        Arguments = serializedArguments;
         return Arguments.Length <= IInvocationMessage.MaxArgumentSize;
     }
-
-    /*
-    TODO: Review custom serialization for the arguments.
-    [MemoryPackOnSerializing]
-    static void WriteArguments<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, ref InvocationMessage? value)
-        where TBufferWriter : class, IBufferWriter<byte>
-    {
-        var initialLength = writer.WriteVarInt();
-        MemoryPackSerializer.Serialize(value._writeArguments.GetType(), ref writer, value._writeArguments);
-        ;
-    }
-
-    [MemoryPackOnDeserializing]
-    static void ReadArguments(ref MemoryPackReader reader, ref InvocationMessage? value)
-    {
-        MemoryPackSerializer.Deserialize()
-        // read custom header before deserialize
-        var guid = reader.ReadUnmanaged<Guid>();
-        Console.WriteLine(guid);
-    }*/
 
     [MemoryPackOnDeserialized]
     private void OnDeserialized()

--- a/src/NexNet/Messages/InvocationResultMessage.cs
+++ b/src/NexNet/Messages/InvocationResultMessage.cs
@@ -1,4 +1,5 @@
 ﻿using System.Buffers;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using MemoryPack;
 using NexNet.Pools;
@@ -40,7 +41,7 @@ internal partial class InvocationResultMessage : IMessageBase
         set => _result = value;
     }
 
-    public bool TryGetResult<T>(out T? result)
+    public bool TryGetResult<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(out T? result)
     {
         if (_result == null)
         {

--- a/src/NexNet/Pipes/Broadcast/NexusBroadcastClient.cs
+++ b/src/NexNet/Pipes/Broadcast/NexusBroadcastClient.cs
@@ -83,7 +83,8 @@ internal abstract class NexusBroadcastClient<TUnion> : NexusBroadcastBase<TUnion
             null,
             null,
             $"Connecting Proxy Collection[{Id}];");
-        await _invoker.ProxyInvokeMethodCore(Id, new ValueTuple<byte>(_invoker.ProxyGetDuplexPipeInitialId(pipe)),
+        var __args = new ValueTuple<byte>(_invoker.ProxyGetDuplexPipeInitialId(pipe));
+        await _invoker.ProxyInvokeMethodCore(Id, MemoryPack.MemoryPackSerializer.Serialize(__args),
             InvocationFlags.DuplexPipe).ConfigureAwait(false);
 
         await pipe.ReadyTask.ConfigureAwait(false);

--- a/src/NexNet/Pools/MessagePool.cs
+++ b/src/NexNet/Pools/MessagePool.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Buffers;
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using MemoryPack;
@@ -13,7 +14,7 @@ namespace NexNet.Pools;
 /// Handles both same-thread and cross-thread rent/return patterns efficiently.
 /// </summary>
 /// <typeparam name="T">Message type to pool.</typeparam>
-internal class MessagePool<T> : IPooledMessage
+internal class MessagePool<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T> : IPooledMessage
     where T : class, IMessageBase, new()
 {
     /// <summary>

--- a/src/NexNet/Pools/PoolManager.cs
+++ b/src/NexNet/Pools/PoolManager.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using NexNet.Internals;
 using NexNet.Internals.Pipelines.Buffers;
@@ -71,7 +72,7 @@ internal class PoolManager
     /// Gets the typed message pool for a specific message type.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public MessagePool<T> Pool<T>()
+    public MessagePool<T> Pool<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>()
         where T : class, IMessageBase, new()
     {
         return Unsafe.As<MessagePool<T>>(_messagePools[((int)T.Type) - MessagePoolOffsetModifier])!;
@@ -88,7 +89,7 @@ internal class PoolManager
     /// <summary>
     /// Rents a message of the specified type.
     /// </summary>
-    public T Rent<T>()
+    public T Rent<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>()
         where T : class, IMessageBase, new()
     {
         return Pool<T>().Rent();

--- a/src/Samples/NexNetSample.Aot.Client/ClientNexus.cs
+++ b/src/Samples/NexNetSample.Aot.Client/ClientNexus.cs
@@ -1,0 +1,33 @@
+using System.Threading.Tasks;
+using NexNet;
+using NexNet.Messages;
+using NexNetSample.Aot.Shared;
+
+namespace NexNetSample.Aot.Client;
+
+[Nexus<IClientNexus, IServerNexus>(NexusType = NexusType.Client)]
+public partial class ClientNexus
+{
+    public ValueTask ReceiveMessage(string user, string message)
+    {
+        Console.WriteLine($"[Client] Received: {user}: {message}");
+        return ValueTask.CompletedTask;
+    }
+
+    public void OnStatusChanged(int status)
+    {
+        Console.WriteLine($"[Client] Status changed to: {status}");
+    }
+
+    protected override ValueTask OnConnected(bool isReconnected)
+    {
+        Console.WriteLine($"[Client] Connected to server (reconnect={isReconnected})");
+        return default;
+    }
+
+    protected override ValueTask OnDisconnected(DisconnectReason reason)
+    {
+        Console.WriteLine($"[Client] Disconnected: {reason}");
+        return default;
+    }
+}

--- a/src/Samples/NexNetSample.Aot.Client/NexNetSample.Aot.Client.csproj
+++ b/src/Samples/NexNetSample.Aot.Client/NexNetSample.Aot.Client.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <PublishAot>true</PublishAot>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NexNetSample.Aot.Shared\NexNetSample.Aot.Shared.csproj" />
+    <ProjectReference Include="..\..\NexNet\NexNet.csproj" />
+    <ProjectReference Include="..\..\NexNet.Generator\NexNet.Generator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" SetTargetFramework="TargetFramework=netstandard2.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/Samples/NexNetSample.Aot.Client/Program.cs
+++ b/src/Samples/NexNetSample.Aot.Client/Program.cs
@@ -1,0 +1,37 @@
+using System.Net;
+using NexNet.Logging;
+using NexNet.Transports;
+using NexNetSample.Aot.Client;
+
+var clientConfig = new TcpClientConfig
+{
+    EndPoint = new IPEndPoint(IPAddress.Loopback, 2345),
+    Logger = new ConsoleLogger { MinLogLevel = NexusLogLevel.Information }
+};
+
+var client = ClientNexus.CreateClient(clientConfig, new ClientNexus());
+
+Console.WriteLine("[Client] Connecting to server...");
+await client.ConnectAsync();
+Console.WriteLine("[Client] Connected!");
+
+// Test fire-and-forget
+client.Proxy.Ping();
+await Task.Delay(100);
+
+// Test method with return value
+var info = await client.Proxy.GetServerInfo();
+Console.WriteLine($"[Client] Server info: {info}");
+
+// Test method with multiple args and return value
+var sum = await client.Proxy.Add(17, 25);
+Console.WriteLine($"[Client] 17 + 25 = {sum}");
+
+// Test awaitable method with args (server broadcasts back to all clients)
+await client.Proxy.SendMessage("AotUser", "Hello from AOT client!");
+await Task.Delay(200);
+
+Console.WriteLine("[Client] All tests complete. Press Enter to disconnect.");
+Console.ReadLine();
+
+await client.DisconnectAsync();

--- a/src/Samples/NexNetSample.Aot.Server/NexNetSample.Aot.Server.csproj
+++ b/src/Samples/NexNetSample.Aot.Server/NexNetSample.Aot.Server.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <PublishAot>true</PublishAot>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NexNetSample.Aot.Shared\NexNetSample.Aot.Shared.csproj" />
+    <ProjectReference Include="..\..\NexNet\NexNet.csproj" />
+    <ProjectReference Include="..\..\NexNet.Generator\NexNet.Generator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" SetTargetFramework="TargetFramework=netstandard2.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/Samples/NexNetSample.Aot.Server/Program.cs
+++ b/src/Samples/NexNetSample.Aot.Server/Program.cs
@@ -1,0 +1,21 @@
+using System.Net;
+using NexNet.Logging;
+using NexNet.Transports;
+using NexNetSample.Aot.Server;
+
+var serverConfig = new TcpServerConfig
+{
+    EndPoint = new IPEndPoint(IPAddress.Loopback, 2345),
+    Logger = new ConsoleLogger { MinLogLevel = NexusLogLevel.Information }
+};
+
+var server = ServerNexus.CreateServer(serverConfig, () => new ServerNexus());
+
+Console.WriteLine("[Server] Starting NexNet AOT server on port 2345...");
+await server.StartAsync();
+Console.WriteLine("[Server] Server started. Press Enter to stop.");
+
+Console.ReadLine();
+
+await server.StopAsync();
+Console.WriteLine("[Server] Server stopped.");

--- a/src/Samples/NexNetSample.Aot.Server/ServerNexus.cs
+++ b/src/Samples/NexNetSample.Aot.Server/ServerNexus.cs
@@ -1,0 +1,45 @@
+using System.Threading.Tasks;
+using NexNet;
+using NexNet.Messages;
+using NexNetSample.Aot.Shared;
+
+namespace NexNetSample.Aot.Server;
+
+[Nexus<IServerNexus, IClientNexus>(NexusType = NexusType.Server)]
+public partial class ServerNexus
+{
+    public void Ping()
+    {
+        Console.WriteLine($"[Server] Ping received from client {Context.Id}");
+    }
+
+    public async ValueTask SendMessage(string user, string message)
+    {
+        Console.WriteLine($"[Server] {user}: {message}");
+
+        // Echo the message back to all connected clients.
+        await Context.Clients.All.ReceiveMessage(user, message).ConfigureAwait(false);
+    }
+
+    public ValueTask<string> GetServerInfo()
+    {
+        return new ValueTask<string>("NexNet AOT Server v1.0");
+    }
+
+    public ValueTask<int> Add(int a, int b)
+    {
+        return new ValueTask<int>(a + b);
+    }
+
+    protected override ValueTask OnConnected(bool isReconnected)
+    {
+        Console.WriteLine($"[Server] Client {Context.Id} connected (reconnect={isReconnected})");
+        return default;
+    }
+
+    protected override ValueTask OnDisconnected(DisconnectReason reason)
+    {
+        Console.WriteLine($"[Server] Client disconnected: {reason}");
+        return default;
+    }
+}

--- a/src/Samples/NexNetSample.Aot.Shared/AOT-FINDINGS.md
+++ b/src/Samples/NexNetSample.Aot.Shared/AOT-FINDINGS.md
@@ -1,0 +1,69 @@
+# NexNet AOT Feasibility Analysis
+
+## Summary
+
+NexNet is **AOT-compatible** with the fixes applied on this branch.
+All NexNet-originated AOT/trim warnings have been resolved.
+The only remaining warnings are from the upstream MemoryPack.Core 1.21.4 dependency.
+
+## Test Results
+
+- Full solution build: **0 warnings, 0 errors**
+- Integration tests: **2622 passed, 0 failed**
+- Generator tests: **148 passed, 0 failed**
+- AOT publish analysis: **Only upstream MemoryPack warnings remain**
+
+## Fixes Applied
+
+### Fix #1 (HIGH) - AOT-safe argument serialization
+**Files:** `IProxyInvoker.cs`, `ProxyInvocationBase.cs`, `SessionInvocationStateManager.cs`,
+`ISessionInvocationStateManager.cs`, `InvocationMessage.cs`, `NexusBroadcastClient.cs`,
+`MethodEmitter.cs` (source generator)
+
+Changed the proxy invocation pipeline from passing `ITuple?` (which required
+`MemoryPackSerializer.Serialize(arguments.GetType(), arguments)` at runtime) to passing
+pre-serialized `Memory<byte>`. The source generator now emits
+`MemoryPackSerializer.Serialize(__proxyInvocationArguments)` at the call site where the
+concrete `ValueTuple<T1, T2, ...>` type is known at compile time.
+
+### Fix #2 - `DeserializeArguments<T>()` annotation
+**Files:** `InvocationMessage.cs`, `IInvocationMessage.cs`
+
+Added `[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]` to the `T`
+parameter on both the interface and implementation to satisfy MemoryPack's requirements.
+
+### Fix #3 - `TryGetResult<T>()` annotation
+**File:** `InvocationResultMessage.cs`
+
+Added `[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]` to the `T` parameter.
+
+### Fix #4 - `MessagePool<T>` and `PoolManager` annotations
+**Files:** `MessagePool.cs`, `PoolManager.cs`
+
+Added `[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]` to the `T`
+parameter on `MessagePool<T>`, `PoolManager.Pool<T>()`, and `PoolManager.Rent<T>()`.
+
+### Fix #5 - `SocketConnection.Counters` reflection removal
+**File:** `SocketConnection.cs`
+
+Replaced the `System.Reflection`-based `Delegate.CreateDelegate` / `GetProperty` approach
+for accessing `Pipe.Length` (a non-public property) with `[UnsafeAccessor]`, which is
+AOT-native and has zero overhead.
+
+### Fix #6 - `Enum.GetValues(Type)` AOT incompatibility
+**File:** `Helpers.cs`
+
+Replaced `Enum.GetValues(typeof(Counter))` with `Enum.GetValues<Counter>()`.
+
+## Remaining Upstream Warnings
+
+| Warning | Source | Notes |
+|---------|--------|-------|
+| IL2104 | MemoryPack.Core 1.21.4 | Assembly-level trim warnings |
+| IL3053 | MemoryPack.Core 1.21.4 | Assembly-level AOT warnings |
+| IL3050 | MemoryPack.Core 1.21.4 | `Enum.GetValues(Type)` in MemoryPack internals |
+
+These are all within the MemoryPack package and cannot be fixed in NexNet.
+MemoryPack uses source-generated formatters, so these warnings are likely
+false positives for the types actually used. A future MemoryPack update
+may resolve these.

--- a/src/Samples/NexNetSample.Aot.Shared/NexNetSample.Aot.Shared.csproj
+++ b/src/Samples/NexNetSample.Aot.Shared/NexNetSample.Aot.Shared.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\NexNet\NexNet.csproj" />
+    <ProjectReference Include="..\..\NexNet.Generator\NexNet.Generator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" SetTargetFramework="TargetFramework=netstandard2.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/Samples/NexNetSample.Aot.Shared/SharedInterfaces.cs
+++ b/src/Samples/NexNetSample.Aot.Shared/SharedInterfaces.cs
@@ -1,0 +1,46 @@
+using System.Threading.Tasks;
+using NexNet;
+
+namespace NexNetSample.Aot.Shared;
+
+/// <summary>
+/// Server-side hub interface - methods callable by the client.
+/// </summary>
+public interface IServerNexus
+{
+    /// <summary>
+    /// Simple fire-and-forget notification.
+    /// </summary>
+    void Ping();
+
+    /// <summary>
+    /// Awaitable method with arguments.
+    /// </summary>
+    ValueTask SendMessage(string user, string message);
+
+    /// <summary>
+    /// Awaitable method with return value.
+    /// </summary>
+    ValueTask<string> GetServerInfo();
+
+    /// <summary>
+    /// Method with multiple argument types to test ValueTuple serialization.
+    /// </summary>
+    ValueTask<int> Add(int a, int b);
+}
+
+/// <summary>
+/// Client-side hub interface - methods callable by the server.
+/// </summary>
+public interface IClientNexus
+{
+    /// <summary>
+    /// Server pushes a message to the client.
+    /// </summary>
+    ValueTask ReceiveMessage(string user, string message);
+
+    /// <summary>
+    /// Server notifies client of a status change.
+    /// </summary>
+    void OnStatusChanged(int status);
+}


### PR DESCRIPTION
NexNet is now AOT-compatible. This PR resolves all NexNet-originated AOT/trim analysis warnings and adds AOT sample projects to validate feasibility. The proxy invocation pipeline was changed from runtime-typed serialization (`ITuple` + `GetType()`) to compile-time serialization via the source generator, and reflection-based code was replaced with AOT-safe alternatives. Additionally, a pre-existing collection sync race condition exposed by the AOT serialization timing change was identified and fixed. All 2628 integration tests and 148 generator tests pass with zero regressions.

## Summary
 - Closes #67

## Reason for Change
NexNet's source generator architecture makes it naturally suited for AOT, but several runtime patterns blocked full AOT compatibility:
- `InvocationMessage.TrySetArguments()` used `MemoryPackSerializer.Serialize(arguments.GetType(), arguments)`, losing compile-time type info through the `ITuple` interface
- Generic methods calling into MemoryPack lacked `[DynamicallyAccessedMembers]` annotations
- `SocketConnection.Counters` used `System.Reflection` to access `Pipe.Length`
- `Helpers.cs` used `Enum.GetValues(typeof(...))` instead of the generic overload

## Impact
- Proxy invocation now serializes arguments at the call site (in generated code) where the concrete `ValueTuple<T1, T2, ...>` type is known, then passes `Memory<byte>` through the invocation pipeline
- `SocketConnection.Counters.GetPipeLength()` now uses `[UnsafeAccessor]` instead of reflection — zero overhead, AOT-native
- Three new sample projects demonstrate AOT usage: `NexNetSample.Aot.Shared`, `NexNetSample.Aot.Server`, `NexNetSample.Aot.Client`
- Only remaining AOT warnings are upstream from MemoryPack.Core 1.21.4 (assembly-level IL2104/IL3053)
- Fixed a pre-existing race condition in `NexusListClient` where stale broadcast messages could duplicate items after collection sync reset

## Bug Fix: Collection sync race condition
A pre-existing race condition in `NexusBroadcastServer.ServerStartCollectionConnection` was exposed by the AOT serialization timing change. When a client connects via `EnableAsync()`, the client is added to `_connectedClients` before the reset sequence is sent via `OnConnected`. Pending broadcast messages in `_messageBroadcastChannel` could be delivered to the newly added client, duplicating operations already included in the reset snapshot. `NexusListClient.OnProcess` lacked version-based deduplication, so the duplicate operations were applied, causing extra items (e.g., `[2, 1, 2]` instead of `[2, 1]`).

**Fix:** Added a version guard in `NexusListClient.OnProcess` that discards incoming operations where `version <= _itemList.Version`. This is safe because broadcast messages carry post-operation versions (monotonically increasing), channels preserve ordering, and server-originated stale broadcasts never carry ACK flags.

## Migration Steps
- **Source generator consumers**: Regenerate code (automatic on rebuild). The generated proxy methods now emit `MemoryPackSerializer.Serialize(args)` and pass `Memory<byte>` instead of `ITuple`.
- **Direct `IProxyInvoker` implementors** (rare/internal): Update method signatures from `ITuple? arguments` to `Memory<byte> serializedArguments`.
- **Direct `ISessionInvocationStateManager` implementors** (rare/internal): Same signature change on `InvokeMethodWithResultCore`.

## Performance Considerations
- Serialization now happens at the generated call site rather than inside `TrySetArguments()` — same work, just moved earlier in the pipeline. No measurable performance difference expected.
- `[UnsafeAccessor]` for `Pipe.Length` is more efficient than the previous `Delegate.CreateDelegate` approach.

## Security Considerations
None. The serialization behavior is unchanged; only the location of serialization moved.

## Breaking Changes
  - Consumer-facing
    - None. Public API is unchanged. Source-generated code is regenerated automatically on rebuild.
  - Internal
    - `IProxyInvoker.ProxyInvokeMethodCore`, `ProxyInvokeAndWaitForResultCore`, `ProxyInvokeAndWaitForResultCore<T>`: parameter changed from `ITuple? arguments` to `Memory<byte> serializedArguments`
    - `ISessionInvocationStateManager.InvokeMethodWithResultCore`: same parameter change
    - `InvocationMessage.TrySetArguments`: parameter changed from `ITuple? arguments` to `Memory<byte> serializedArguments`
    - `SocketConnection.Counters`: removed static constructor, `s_pipeLengthReader` field, and `System.Reflection` dependency; replaced with `[UnsafeAccessor]`