### PR TITLE
Fix non-deterministic HashLock in source generator

### DIFF
--- a/src/NexNet.Generator.Tests/VersioningTests.cs
+++ b/src/NexNet.Generator.Tests/VersioningTests.cs
@@ -78,7 +78,7 @@ partial class DataObject {
     public int Value2 { get; set; } 
 }
 partial interface IClientNexus { }
-[NexusVersion(Version = "v2", HashLock=1729262913)]
+[NexusVersion(Version = "v2", HashLock=-866266143)]
 partial interface IServerNexus {
     [NexusMethod(100)]
     void Update(DataObject data, List<ValueTuple<Tuple<DataObject, int>>> data2);
@@ -109,12 +109,12 @@ internal partial class Message2 {
     [MemoryPackOrder(1)] public int TotalValuesDiff { get; set; }
 }
 partial interface IClientNexus { }
-[NexusVersion(Version = "v1", HashLock = -823364119)]
+[NexusVersion(Version = "v1", HashLock = -1823135581)]
 partial interface IServerNexus {
     [NexusMethod(100)]
     void Update(Message data);
 }
-[NexusVersion(Version = "v1", HashLock = -911867615)]
+[NexusVersion(Version = "v1", HashLock = -1716870845)]
 partial interface IServerNexus2 {
     [NexusMethod(100)]
     void Update(Message2 data);
@@ -198,7 +198,7 @@ internal partial class ValueObjects {
     [MemoryPackOrder(0)] public string[] Values { get; set; }
 }
 partial interface IClientNexus { }
-[NexusVersion(Version = "v1", HashLock = 49619989)]
+[NexusVersion(Version = "v1", HashLock = -429959377)]
 partial interface IServerNexus {
     [NexusMethod(100)]
     void Update(ValueTuple<Message> data);

--- a/src/NexNet.Generator/Extraction/NexusDataExtractor.cs
+++ b/src/NexNet.Generator/Extraction/NexusDataExtractor.cs
@@ -150,7 +150,9 @@ internal static class NexusDataExtractor
 
         // Build interface hierarchy first to create method/collection tables
         var interfaceMap = new Dictionary<INamedTypeSymbol, InvocationInterfaceData>(SymbolEqualityComparer.Default);
-        var allInterfaceSymbols = symbol.AllInterfaces.ToList();
+        var allInterfaceSymbols = symbol.AllInterfaces
+            .OrderBy(i => i.ToDisplayString(), StringComparer.Ordinal)
+            .ToList();
 
         // Extract methods from this interface directly
         var directMethods = ExtractMethodsFromMembers(symbol.GetMembers(), typeHasher);
@@ -285,7 +287,7 @@ internal static class NexusDataExtractor
         var allMethods = new List<MethodData>(interfaceMethods);
         var allCollections = new List<CollectionData>(interfaceCollections);
 
-        foreach (var inherited in symbol.AllInterfaces)
+        foreach (var inherited in symbol.AllInterfaces.OrderBy(i => i.ToDisplayString(), StringComparer.Ordinal))
         {
             var inheritedMethods = ExtractMethodsFromMembers(inherited.GetMembers(), typeHasher)
                 .Where(m => !m.MethodAttribute.Ignore);
@@ -902,7 +904,7 @@ internal static class NexusDataExtractor
         List<MethodParameterData> parameters,
         NexusMethodAttributeData methodAttr)
     {
-        var hash = new HashCode();
+        var hash = new IncrementalHasher();
 
         var returnSymbol = symbol.ReturnType as INamedTypeSymbol;
         if (returnSymbol?.Arity > 0)
@@ -931,7 +933,7 @@ internal static class NexusDataExtractor
         string? itemType,
         NexusCollectionAttributeData collectionAttr)
     {
-        var hash = new HashCode();
+        var hash = new IncrementalHasher();
 
         if (itemType != null)
         {
@@ -955,7 +957,7 @@ internal static class NexusDataExtractor
         MethodData[] methods,
         CollectionData[] collections)
     {
-        var hash = new HashCode();
+        var hash = new IncrementalHasher();
 
         foreach (var method in methods)
             hash.Add(method.NexusHash);

--- a/src/NexNet.Generator/TypeHasher.cs
+++ b/src/NexNet.Generator/TypeHasher.cs
@@ -432,7 +432,9 @@ internal sealed class TypeHasher
         {
             if (member is IFieldSymbol { ConstantValue: not null } field)
             {
-                fields[idx++] = (field.Name, field.Name.GetHashCode(), Convert.ToInt64(field.ConstantValue));
+                var nameHasher = new IncrementalHasher();
+                nameHasher.AddString(field.Name);
+                fields[idx++] = (field.Name, nameHasher.ToHashCode(), Convert.ToInt64(field.ConstantValue));
             }
         }
 

--- a/src/NexNet.IntegrationTests/TestInterfaces/VersionedTestsInterfaces.cs
+++ b/src/NexNet.IntegrationTests/TestInterfaces/VersionedTestsInterfaces.cs
@@ -15,14 +15,14 @@ public partial interface ISimpleClientNexus
 }
 
 
-[NexusVersion(Version = "v1.0", HashLock = 49342072)]
+[NexusVersion(Version = "v1.0", HashLock = -1085487423)]
 public partial interface IVersionedServerNexusV1
 {
     [NexusMethod(1)]
     ValueTask<bool> VerifyVersionV1(string version);
 }
 
-[NexusVersion(Version = "v1.1", HashLock = 311996033)]
+[NexusVersion(Version = "v1.1", HashLock = 778731763)]
 public partial interface IVersionedServerNexusV1_1 : IVersionedServerNexusV1
 {
     [NexusMethod(2)]
@@ -39,7 +39,7 @@ public partial interface IVersionedServerNexusV1_1 : IVersionedServerNexusV1
     }
 }
 
-[NexusVersion(Version = "v1.2", HashLock = -1007258537)]
+[NexusVersion(Version = "v1.2", HashLock = 467572850)]
 public partial interface IVersionedServerNexusV2 : IVersionedServerNexusV1_1
 {
     [NexusMethod(4)]

--- a/src/Samples/NexNetDemo/Samples/Versioning/VersioningSample.cs
+++ b/src/Samples/NexNetDemo/Samples/Versioning/VersioningSample.cs
@@ -6,7 +6,7 @@ namespace NexNetDemo.Samples.Versioning;
 
 
 // V1 Server Interface - Initial version with one method
-[NexusVersion(Version = "v1.0", HashLock = -2031775281)]
+[NexusVersion(Version = "v1.0", HashLock = -273416360)]
 public interface IVersioningNexusServerV1
 {
     [NexusMethod(1)]
@@ -24,7 +24,7 @@ public partial class NexusServerV1
 }
 
 // V2 Server Interface - Inherits from V1 and adds new method
-[NexusVersion(Version = "v2.0", HashLock = -1210855623)]
+[NexusVersion(Version = "v2.0", HashLock = 1950812484)]
 public interface IVersioningNexusServerV2 : IVersioningNexusServerV1
 {
     [NexusMethod(2)]


### PR DESCRIPTION
## Summary
- Fixes non-deterministic `HashLock` values produced by the source generator on every build

## Reason for Change
`System.HashCode` uses a randomized per-process seed in .NET Core, causing `ComputeMethodHash`, `ComputeCollectionHash`, and `ComputeInterfaceHash` to produce different values across builds. Additionally, `string.GetHashCode()` in `TypeHasher.ProcessEnum` is also non-deterministic. Users with `[NexusVersion(HashLock = ...)]` attributes would see NEXNET019 errors on every build with a different compiler process.

## Impact
- All computed `HashLock` values change — users must regenerate them after upgrading (see #68)
- No wire protocol or runtime impact; `HashLock` is compile-time only

## Plan items implemented as specified
1. Replaced `new HashCode()` with `new IncrementalHasher()` (FNV-1a, fixed seed) in `ComputeMethodHash`, `ComputeCollectionHash`, `ComputeInterfaceHash`
2. Replaced `field.Name.GetHashCode()` with deterministic `IncrementalHasher`-based hash in `TypeHasher.ProcessEnum`
3. Sorted `AllInterfaces` by FQN (`StringComparer.Ordinal`) for stable ordering across compilations
4. Updated hardcoded `HashLock` values in generator tests and integration test interfaces

## Deviations from plan implemented
None.

## Gaps in original plan implemented
None.

## Migration Steps
Users with `[NexusVersion(HashLock = X)]` attributes will get NEXNET019 errors after upgrading. The error message provides the new correct value — update the `HashLock` attribute to match.

## Performance Considerations
`IncrementalHasher` is a stack-allocated `ref struct` using FNV-1a — equivalent or better performance than `System.HashCode`.

## Security Considerations
None. Hash values are for API versioning integrity, not cryptographic purposes.

## Breaking Changes
- Consumer-facing: All `HashLock` values change. Users must regenerate after upgrading.
- Internal: None.

## Related Issues
- #68: Document HashLock value changes in release notes
- #69: Add determinism regression test for source generator hashing