### PR TITLE
Add AOT sample projects to CI build validation

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -34,7 +34,10 @@ jobs:
 
     - name: Build
       run: dotnet build src -c Release --maxcpucount:1
-      
+
+    - name: Validate AOT compatibility
+      run: dotnet build src/Samples/NexNetSample.Aot.Client -c Release --no-restore -p:TreatWarningsAsErrors=true -p:NoWarn=IL2104%3BIL3053%3BIL3050
+
     - name: Execute integration tests
       run: dotnet test src/NexNet.IntegrationTests -c Release --no-build -v=normal
 

--- a/src/NexNet.slnx
+++ b/src/NexNet.slnx
@@ -8,6 +8,9 @@
     <Project Path="Samples\NexNetSample.Asp.Client\NexNetSample.Asp.Client.csproj" Type="C#" />
     <Project Path="Samples\NexNetSample.Asp.Server\NexNetSample.Asp.Server.csproj" Type="C#" />
     <Project Path="Samples\NexNetSample.Asp.Shared\NexNetSample.Asp.Shared.csproj" Type="C#" />
+    <Project Path="Samples\NexNetSample.Aot.Client\NexNetSample.Aot.Client.csproj" Type="C#" />
+    <Project Path="Samples\NexNetSample.Aot.Server\NexNetSample.Aot.Server.csproj" Type="C#" />
+    <Project Path="Samples\NexNetSample.Aot.Shared\NexNetSample.Aot.Shared.csproj" Type="C#" />
   </Folder>
   <Folder Name="/Solution Items/">
     <File Path="NexNet.props" />


### PR DESCRIPTION
## Summary
- Closes #71

## Reason for Change
The three AOT sample projects added in PR #66 (`NexNetSample.Aot.Client`, `NexNetSample.Aot.Server`, `NexNetSample.Aot.Shared`) were not included in `NexNet.slnx` and therefore not built by `dotnet build src` or validated in CI. A future change breaking AOT compatibility would go unnoticed.

## Impact
- `dotnet build src` now compiles the AOT sample projects, catching compile-time regressions
- CI pipeline gains a new "Validate AOT compatibility" step that treats AOT/trim analyzer warnings as errors
- Known upstream MemoryPack warnings (IL2104, IL3053, IL3050) are suppressed

## Plan items implemented as specified
1. Added `NexNetSample.Aot.Client`, `NexNetSample.Aot.Server`, and `NexNetSample.Aot.Shared` to the `/Samples/` folder in `NexNet.slnx`
2. Added a CI step that builds `NexNetSample.Aot.Client` with `-p:TreatWarningsAsErrors=true` and suppresses known MemoryPack warnings

## Deviations from plan implemented
- Used `%3B` MSBuild-encoded semicolons in the `NoWarn` property value instead of literal semicolons, as required for correct shell/MSBuild parsing

## Gaps in original plan implemented
None.

## Migration Steps
None required.

## Performance Considerations
- CI build time increases slightly due to building 3 additional sample projects and the AOT validation step
- The AOT validation step uses `--no-restore` to avoid redundant package restore

## Security Considerations
None. No new dependencies, no secret handling, no input processing.

## Breaking Changes
- Consumer-facing: None
- Internal: Developers running `dotnet build src` will now also build the AOT sample projects (requires .NET 10 SDK, consistent with existing repo target)
